### PR TITLE
Include Binder Type in Adapter Parameters; Include Adapter Binder Type in Binder Parameters

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.tumblr.graywater"
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "0.0.2"
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/tumblr/example/PrimitiveAdapter.java
+++ b/app/src/main/java/com/tumblr/example/PrimitiveAdapter.java
@@ -22,7 +22,11 @@ import com.tumblr.graywater.GraywaterAdapter;
 /**
  * Created by ericleong on 3/13/16.
  */
-public class PrimitiveAdapter extends GraywaterAdapter<Primitive, PrimitiveViewHolder, Class<? extends Primitive>> {
+public class PrimitiveAdapter extends GraywaterAdapter<
+		Primitive,
+		PrimitiveViewHolder,
+		GraywaterAdapter.Binder<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>,
+		Class<? extends Primitive>> {
 
 	public PrimitiveAdapter() {
 		register(new TextPrimitiveViewHolderCreator(), TextPrimitiveViewHolder.class);
@@ -33,9 +37,9 @@ public class PrimitiveAdapter extends GraywaterAdapter<Primitive, PrimitiveViewH
 		final TextPrimitiveBinder<ColorNamePrimitive> colorNameTextBinder = new TextPrimitiveBinder<>();
 		final ColorNameToastBinder colorNameToastBinder = new ColorNameToastBinder();
 
-		final ColorNamePrimitiveItemBinder colorNamePrimitiveBinderList =
+		final ColorNamePrimitiveItemBinder colorNamePrimitiveItemBinder =
 				new ColorNamePrimitiveItemBinder(this, colorNameTextBinder, colorNameToastBinder);
-		register(ColorNamePrimitive.class, colorNamePrimitiveBinderList, colorNamePrimitiveBinderList);
+		register(ColorNamePrimitive.class, colorNamePrimitiveItemBinder, colorNamePrimitiveItemBinder);
 
 		// A header always displays the same text
 		final HeaderBinder headerBinder = new HeaderBinder();

--- a/app/src/main/java/com/tumblr/example/binder/ColorNameToastBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/ColorNameToastBinder.java
@@ -1,8 +1,10 @@
 package com.tumblr.example.binder;
 
 import android.support.annotation.NonNull;
+import com.tumblr.example.R;
 import com.tumblr.example.model.ColorNamePrimitive;
 import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
+import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
 import java.util.List;
@@ -10,17 +12,17 @@ import java.util.List;
 /**
  * Created by ericleong on 3/24/16.
  */
-public class ColorNameToastBinder implements GraywaterAdapter.Binder<ColorNamePrimitive, ColorPrimitiveViewHolder> {
+public class ColorNameToastBinder implements GraywaterAdapter.Binder<ColorNamePrimitive,PrimitiveViewHolder,ColorPrimitiveViewHolder> {
 
-	@NonNull
 	@Override
-	public Class<ColorPrimitiveViewHolder> getViewHolderType() {
-		return ColorPrimitiveViewHolder.class;
+	public int getViewType(final ColorNamePrimitive model) {
+		return R.layout.item_color;
 	}
 
 	@Override
 	public void prepare(@NonNull final ColorNamePrimitive model,
-	                    final List<GraywaterAdapter.Binder<? super ColorNamePrimitive, ? extends ColorPrimitiveViewHolder>> binders,
+	                    @NonNull final List<GraywaterAdapter.Binder<
+			                    ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                    final int binderIndex) {
 
 	}
@@ -28,9 +30,11 @@ public class ColorNameToastBinder implements GraywaterAdapter.Binder<ColorNamePr
 	@Override
 	public void bind(@NonNull final ColorNamePrimitive model,
 	                 @NonNull final ColorPrimitiveViewHolder holder,
-	                 @NonNull final List<GraywaterAdapter.Binder<? super ColorNamePrimitive, ? extends ColorPrimitiveViewHolder>> binders,
+	                 @NonNull final List<GraywaterAdapter.Binder<
+			                 ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                 final int binderIndex,
-	                 @NonNull final GraywaterAdapter.ActionListener<ColorNamePrimitive, ColorPrimitiveViewHolder> actionListener) {
+	                 @NonNull final GraywaterAdapter.ActionListener<
+			                 ColorNamePrimitive, PrimitiveViewHolder, ColorPrimitiveViewHolder> actionListener) {
 		holder.getView().setBackgroundColor(holder.getView().getResources().getColor(model.getColor()));
 		holder.getActionListenerDelegate().update(actionListener, model, holder, binders, binderIndex, null);
 		holder.getView().setOnClickListener(holder.getActionListenerDelegate());

--- a/app/src/main/java/com/tumblr/example/binder/HeaderBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/HeaderBinder.java
@@ -1,29 +1,28 @@
 package com.tumblr.example.binder;
 
 import android.support.annotation.NonNull;
-import android.util.Log;
-import android.view.ViewGroup;
-import com.tumblr.graywater.GraywaterAdapter;
 import com.tumblr.example.R;
 import com.tumblr.example.model.Primitive;
 import com.tumblr.example.viewholder.HeaderViewHolder;
+import com.tumblr.example.viewholder.PrimitiveViewHolder;
+import com.tumblr.graywater.GraywaterAdapter;
 
 import java.util.List;
 
 /**
  * Created by ericleong on 3/13/16.
  */
-public class HeaderBinder implements GraywaterAdapter.Binder<Primitive.Header, HeaderViewHolder> {
+public class HeaderBinder implements GraywaterAdapter.Binder<Primitive.Header,PrimitiveViewHolder,HeaderViewHolder> {
 
-	@NonNull
 	@Override
-	public Class<HeaderViewHolder> getViewHolderType() {
-		return HeaderViewHolder.class;
+	public int getViewType(final Primitive.Header model) {
+		return R.layout.item_header;
 	}
 
 	@Override
 	public void prepare(@NonNull final Primitive.Header model,
-	                    final List<GraywaterAdapter.Binder<? super Primitive.Header, ? extends HeaderViewHolder>> binders,
+	                    @NonNull final List<GraywaterAdapter.Binder<
+			                    ? super Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                    final int binderIndex) {
 
 	}
@@ -31,9 +30,11 @@ public class HeaderBinder implements GraywaterAdapter.Binder<Primitive.Header, H
 	@Override
 	public void bind(@NonNull final Primitive.Header model,
 	                 @NonNull final HeaderViewHolder holder,
-	                 @NonNull final List<GraywaterAdapter.Binder<? super Primitive.Header, ? extends HeaderViewHolder>> binders,
+	                 @NonNull final List<GraywaterAdapter.Binder<
+			                 ? super Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                 final int binderIndex,
-	                 @NonNull final GraywaterAdapter.ActionListener<Primitive.Header, HeaderViewHolder> actionListener) {
+	                 @NonNull final GraywaterAdapter.ActionListener<
+			                 Primitive.Header, PrimitiveViewHolder, HeaderViewHolder> actionListener) {
 
 	}
 

--- a/app/src/main/java/com/tumblr/example/binder/PaletteColorBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/PaletteColorBinder.java
@@ -3,8 +3,10 @@ package com.tumblr.example.binder;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.Toast;
+import com.tumblr.example.R;
 import com.tumblr.example.model.Palette;
 import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
+import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
 import java.util.List;
@@ -12,17 +14,17 @@ import java.util.List;
 /**
  * Created by ericleong on 3/13/16.
  */
-public class PaletteColorBinder implements GraywaterAdapter.Binder<Palette, ColorPrimitiveViewHolder> {
+public class PaletteColorBinder implements GraywaterAdapter.Binder<Palette,PrimitiveViewHolder,ColorPrimitiveViewHolder> {
 
-	@NonNull
 	@Override
-	public Class<ColorPrimitiveViewHolder> getViewHolderType() {
-		return ColorPrimitiveViewHolder.class;
+	public int getViewType(final Palette model) {
+		return R.layout.item_color;
 	}
 
 	@Override
 	public void prepare(@NonNull final Palette model,
-	                    final List<GraywaterAdapter.Binder<? super Palette, ? extends ColorPrimitiveViewHolder>> binders,
+	                    @NonNull final List<GraywaterAdapter.Binder<
+			                    ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                    final int binderIndex) {
 
 	}
@@ -30,9 +32,11 @@ public class PaletteColorBinder implements GraywaterAdapter.Binder<Palette, Colo
 	@Override
 	public void bind(@NonNull final Palette model,
 	                 @NonNull final ColorPrimitiveViewHolder holder,
-	                 @NonNull final List<GraywaterAdapter.Binder<? super Palette, ? extends ColorPrimitiveViewHolder>> binders,
+	                 @NonNull final List<GraywaterAdapter.Binder<
+			                 ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                 final int binderIndex,
-	                 @NonNull final GraywaterAdapter.ActionListener<Palette, ColorPrimitiveViewHolder> actionListener) {
+	                 @NonNull final GraywaterAdapter.ActionListener<
+			                 Palette, PrimitiveViewHolder, ColorPrimitiveViewHolder> actionListener) {
 		holder.getView().setBackgroundColor(holder.getView().getResources().getColor(model.getColors().get
 				(binderIndex - 1)));
 

--- a/app/src/main/java/com/tumblr/example/binder/TextPrimitiveBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/TextPrimitiveBinder.java
@@ -1,38 +1,38 @@
 package com.tumblr.example.binder;
 
 import android.support.annotation.NonNull;
-import android.view.ViewGroup;
-import com.tumblr.graywater.GraywaterAdapter;
 import com.tumblr.example.R;
 import com.tumblr.example.model.Primitive;
+import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.example.viewholder.TextPrimitiveViewHolder;
+import com.tumblr.graywater.GraywaterAdapter;
 
 import java.util.List;
 
 /**
  * Created by ericleong on 3/13/16.
  */
-public class TextPrimitiveBinder<U extends Primitive.Text> implements GraywaterAdapter.Binder<U, TextPrimitiveViewHolder> {
-
-	@NonNull
+public class TextPrimitiveBinder<T extends Primitive.Text>
+		implements GraywaterAdapter.Binder<T,PrimitiveViewHolder,TextPrimitiveViewHolder> {
 	@Override
-	public Class<TextPrimitiveViewHolder> getViewHolderType() {
-		return TextPrimitiveViewHolder.class;
+	public int getViewType(final T model) {
+		return R.layout.item_text;
 	}
 
 	@Override
-	public void prepare(@NonNull final U model,
-	                    final List<GraywaterAdapter.Binder<? super U, ? extends TextPrimitiveViewHolder>> binders,
+	public void prepare(@NonNull final T model,
+	                    @NonNull final List<GraywaterAdapter.Binder<
+			                    ? super T, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                    final int binderIndex) {
 
 	}
 
 	@Override
-	public void bind(@NonNull final U model,
+	public void bind(@NonNull final T model,
 	                 @NonNull final TextPrimitiveViewHolder holder,
-	                 @NonNull final List<GraywaterAdapter.Binder<? super U, ? extends TextPrimitiveViewHolder>> binders,
+	                 @NonNull final List<GraywaterAdapter.Binder<? super T, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                 final int binderIndex,
-	                 @NonNull final GraywaterAdapter.ActionListener<U, TextPrimitiveViewHolder> actionListener) {
+	                 @NonNull final GraywaterAdapter.ActionListener<T, PrimitiveViewHolder, TextPrimitiveViewHolder> actionListener) {
 		holder.getTextView().setText(model.getString());
 	}
 

--- a/app/src/main/java/com/tumblr/example/binderlist/ColorNamePrimitiveItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/ColorNamePrimitiveItemBinder.java
@@ -18,8 +18,9 @@ import java.util.List;
  * Created by ericleong on 3/28/16.
  */
 public class ColorNamePrimitiveItemBinder
-		implements GraywaterAdapter.ItemBinder<ColorNamePrimitive, PrimitiveViewHolder>,
-		GraywaterAdapter.ActionListener<ColorNamePrimitive, PrimitiveViewHolder> {
+		implements GraywaterAdapter.ItemBinder<ColorNamePrimitive, PrimitiveViewHolder,
+		GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>,
+		GraywaterAdapter.ActionListener<ColorNamePrimitive, PrimitiveViewHolder, PrimitiveViewHolder> {
 
 	private final TextPrimitiveBinder<ColorNamePrimitive> mColorNameTextBinder;
 	private final ColorNameToastBinder mColorNameToastBinder;
@@ -36,9 +37,9 @@ public class ColorNamePrimitiveItemBinder
 
 	@NonNull
 	@Override
-	public List<GraywaterAdapter.Binder<? super ColorNamePrimitive, ? extends PrimitiveViewHolder>> getBinderList(
-			@NonNull final ColorNamePrimitive model, final int position) {
-		return new ArrayList<GraywaterAdapter.Binder<? super ColorNamePrimitive, ? extends PrimitiveViewHolder>>() {{
+	public List<GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	getBinderList(@NonNull final ColorNamePrimitive model, final int position) {
+		return new ArrayList<GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>() {{
 			add(mColorNameTextBinder);
 			add(mColorNameToastBinder);
 		}};
@@ -48,12 +49,13 @@ public class ColorNamePrimitiveItemBinder
 	public void act(@NonNull final ColorNamePrimitive model,
 	                @NonNull final PrimitiveViewHolder holder,
 	                @NonNull final View v,
-	                @NonNull final List<GraywaterAdapter.Binder<? super ColorNamePrimitive, ? extends PrimitiveViewHolder>> binders,
+	                @NonNull final List<GraywaterAdapter.Binder<
+			                ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                final int binderIndex,
 	                @Nullable final Object obj) {
 		Toast.makeText(v.getContext(), model.getString(), Toast.LENGTH_SHORT).show();
 
 		mAdapter.add(mAdapter.getItemPosition(holder.getAdapterPosition()) + 1,
-				new ColorNamePrimitive(model.getColor(), model.getString() + "+"));
+				new ColorNamePrimitive(model.getColor(), model.getString() + "+"), true);
 	}
 }

--- a/app/src/main/java/com/tumblr/example/binderlist/HeaderPrimitiveItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/HeaderPrimitiveItemBinder.java
@@ -12,7 +12,9 @@ import java.util.List;
 /**
  * Created by ericleong on 3/28/16.
  */
-public class HeaderPrimitiveItemBinder implements GraywaterAdapter.ItemBinder<Primitive.Header, PrimitiveViewHolder> {
+public class HeaderPrimitiveItemBinder implements
+		GraywaterAdapter.ItemBinder<Primitive.Header, PrimitiveViewHolder,
+				GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> {
 	private final HeaderBinder mHeaderBinder;
 
 	public HeaderPrimitiveItemBinder(final HeaderBinder headerBinder) {
@@ -21,9 +23,9 @@ public class HeaderPrimitiveItemBinder implements GraywaterAdapter.ItemBinder<Pr
 
 	@NonNull
 	@Override
-	public List<GraywaterAdapter.Binder<? super Primitive.Header, ? extends PrimitiveViewHolder>> getBinderList(
-			@NonNull final Primitive.Header model, final int position) {
-		return new ArrayList<GraywaterAdapter.Binder<? super Primitive.Header, ? extends PrimitiveViewHolder>>() {{
+	public List<GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	getBinderList(@NonNull final Primitive.Header model, final int position) {
+		return new ArrayList<GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>() {{
 			add(mHeaderBinder);
 		}};
 	}

--- a/app/src/main/java/com/tumblr/example/binderlist/PaletteItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/PaletteItemBinder.java
@@ -15,8 +15,9 @@ import java.util.List;
 /**
  * Created by ericleong on 3/28/16.
  */
-public class PaletteItemBinder implements GraywaterAdapter.ItemBinder<Palette, PrimitiveViewHolder>,
-		GraywaterAdapter.ActionListener<Palette, PrimitiveViewHolder> {
+public class PaletteItemBinder implements GraywaterAdapter.ItemBinder<Palette, PrimitiveViewHolder,
+		GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>,
+		GraywaterAdapter.ActionListener<Palette, PrimitiveViewHolder, PrimitiveViewHolder> {
 	private final TextPrimitiveBinder<Palette> mPaletteTextPrimitiveBinder;
 	private final PaletteColorBinder mPaletteColorBinder;
 
@@ -27,9 +28,9 @@ public class PaletteItemBinder implements GraywaterAdapter.ItemBinder<Palette, P
 
 	@NonNull
 	@Override
-	public List<GraywaterAdapter.Binder<? super Palette, ? extends PrimitiveViewHolder>> getBinderList(
-			@NonNull final Palette model, final int position) {
-		return new ArrayList<GraywaterAdapter.Binder<? super Palette, ? extends PrimitiveViewHolder>>() {{
+	public List<GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	getBinderList(@NonNull final Palette model, final int position) {
+		return new ArrayList<GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>() {{
 			add(mPaletteTextPrimitiveBinder);
 
 			for (int color : model.getColors()) {
@@ -42,7 +43,8 @@ public class PaletteItemBinder implements GraywaterAdapter.ItemBinder<Palette, P
 	public void act(@NonNull final Palette model,
 	                @NonNull final PrimitiveViewHolder holder,
 	                @NonNull final View v,
-	                @NonNull final List<GraywaterAdapter.Binder<? super Palette, ? extends PrimitiveViewHolder>> binders,
+	                @NonNull final List<GraywaterAdapter.Binder<
+			                ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
 	                final int binderIndex,
 	                @Nullable final Object obj) {
 

--- a/app/src/main/java/com/tumblr/example/viewholder/ColorPrimitiveViewHolder.java
+++ b/app/src/main/java/com/tumblr/example/viewholder/ColorPrimitiveViewHolder.java
@@ -10,7 +10,7 @@ import com.tumblr.graywater.GraywaterAdapter;
  */
 public class ColorPrimitiveViewHolder extends PrimitiveViewHolder {
 
-	private GraywaterAdapter.ActionListenerDelegate<ColorNamePrimitive, ColorPrimitiveViewHolder>
+	private GraywaterAdapter.ActionListenerDelegate<ColorNamePrimitive, PrimitiveViewHolder, ColorPrimitiveViewHolder>
 			mActionListenerDelegate = new GraywaterAdapter.ActionListenerDelegate<>();
 
 	private final View view;
@@ -24,7 +24,8 @@ public class ColorPrimitiveViewHolder extends PrimitiveViewHolder {
 		return view;
 	}
 
-	public GraywaterAdapter.ActionListenerDelegate<ColorNamePrimitive, ColorPrimitiveViewHolder> getActionListenerDelegate() {
+	public GraywaterAdapter.ActionListenerDelegate<ColorNamePrimitive, PrimitiveViewHolder, ColorPrimitiveViewHolder>
+	getActionListenerDelegate() {
 		return mActionListenerDelegate;
 	}
 }


### PR DESCRIPTION
### Include Binder Type in Adapter Parameters

This adds `B extends GraywaterAdapter.Binder<? extends T, VH, ? extends VH>` to `GraywaterAdapter`. The benefits of this change have yet to be fully exploited but one current benefit is that all binders would be required to be of type `B`, which may be useful if there is some behavior that is common to all binders.

### Include Adapter Binder Type in Binder Parameters

Note that `Binder.bind()` takes a list of binders but that list of binders are bound by the type constraints of `ItemBinder`, but we still want to keep the viewholder type as close to the concrete type as possible to minimize casting.

#### Before

```java
public interface Binder<U, V extends RecyclerView.ViewHolder> {
    void bind(@NonNull U model, 
              @NonNull V holder, 
              @NonNull List<Binder<? super U, ? extends V>> binderList,
              int binderIndex, 
              @NonNull ActionListener<U, V> actionListener);
}
```

#### After

```java
public interface Binder<U, V extends RecyclerView.ViewHolder, W extends V> {
    void bind(@NonNull U model, 
              @NonNull W holder, 
              @NonNull List<Binder<? super U, V, ? extends V>> binderList,
              int binderIndex, 
              @NonNull ActionListener<U, V, W> actionListener);
}
```

* `V` now corresponds the the viewholder (`VH`) in `GraywaterAdapter<T, VH, B, MT>`
* `W` is the old `V`, which represents the viewholder the binder is binding to.

This is now "correct" since the list passed by Graywater into the binder is only guaranteed to be a list constrained by `VH`.

For example, if your adapter extends `GraywaterAdapter<Text, TextViewHolder, ..., ...>` then two valid binders could be:

* `Binder<Title, TextViewHolder, TitleViewHolder>`
* `Binder<Body, TextViewHolder, BodyViewHolder>`

An `ItemBinder` can contain both by being of the type `ItemBinder<Text, TextViewHolder, Binder<Text, TextViewHolder, ? extends TextViewHolder>`.

The list of binders passed to the `Title` binder would be `Binder<? super Title, TextViewHolder, ? extends TextViewHolder>`. Previously, it was `Binder<? super Title, ? extends TitleViewHolder>`, which is technically wrong because `? extends TitleViewHolder` implies that the binder is a part of a list of titles. This only worked because of type erasure.