### PR TITLE
Use Dagger 2 Map Multibinding to Inject Binders in Example Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ One naive solution is to map models directly to viewholders. For example, a list
 So to improve performance, the parts of a post that are offscreen can be recycled.
 
 ```
-   model      views
+   model       views
 +---------+   +------+ 
 |         |   | head | <------- does not exist
 |         |   +------+ <------------+
@@ -105,7 +105,7 @@ A minor design point is that `RecyclerView.Adapter#onCreate()` creates the viewh
 
 ### Dependency Injection with Dagger 2 Map Multibindings
 
-For Graywater to know about the ItemBinders and ViewHolderCreators, each of them need to be registered when the adapter is created. When there are a substantial number of both, there can be a significant impact on the time it takes to initialize the adapter.
+For Graywater to know about the ItemBinders and ViewHolderCreators, each of them needs to be registered when the adapter is created. When there are a substantial number of both, there can be a significant impact on the time it takes to initialize the adapter.
 
 One solution is to use [Dagger 2 map multibindings](https://google.github.io/dagger/multibindings#map-multibindings). This allows you to use the full power of dependency injection to control which binders a given screen will support, as well as the ability to inject different versions of the same binder on different screens to facilitate screen-dependent behavior.
 
@@ -129,7 +129,7 @@ _Note that Graywater does not have built-in support for Dagger 2._
 
 ### Lazy Loading Binders
 
-Normally, when an item is added to the adapter, the corresponding an `ItemBinder` is loaded as well as all the necessary `Binder` classes.
+Normally, when an item is added to the adapter, the corresponding `ItemBinder` is loaded as well as all the necessary `Binder` classes.
 
 ```
  Binders             ItemBinders                Items             Screen  

--- a/README.md
+++ b/README.md
@@ -103,12 +103,15 @@ A minor design point is that `RecyclerView.Adapter#onCreate()` creates the viewh
                    +--------+     +------------+     +-------------------+
 ```
 
+### Dependency Injection with Dagger 2 Map Multibindings
 
-Because binders should not contain per-item state, it is better to use dependency injection to inject the binders into the list of binders. To facilitate this, a **BinderProvider** is used to provide binders to item binders. It is also used to provide the `ViewHolderCreator` instances (although this is just for convenience). By doing this, related `Binder`, `ItemBinder` and `ViewHolderCreator` classes can be grouped together.
+For Graywater to know about the ItemBinders and ViewHolderCreators, each of them need to be registered when the adapter is created. When there are a substantial number of both, there can be a significant impact on the time it takes to initialize the adapter.
+
+One solution is to use [Dagger 2 map multibindings](https://google.github.io/dagger/multibindings#map-multibindings). This allows you to use the full power of dependency injection to control which binders a given screen will support, as well as the ability to inject different versions of the same binder on different screens to facilitate screen-dependent behavior.
 
 ```
                  +------------+                       +----------------+
-         /-----> | ItemBinder | <-------------------- | BinderProvider |
+         /-----> | ItemBinder | <-------------------- | Dagger 2 Maps  |
         /        +------------+                       +----------------+
        /               v                                       v
       /            +--------+     +------------+     +-------------------+
@@ -119,6 +122,44 @@ Because binders should not contain per-item state, it is better to use dependenc
             \----> | Binder | --> | ViewHolder | <-- | ViewHolderCreator |
                    +--------+     +------------+     +-------------------+
 ```
+
+But using Dagger 2 by itself does not improve startup time, because the maps are created at injection time, which requires all the binders to also be created. This can be somewhat alleviated with `Lazy<Map>`, but another benefit of Dagger 2 is the automatic support for `Map<K, Provider<V>>`. When applied to `ItemBinders`, this allows each `ItemBinder` to be constructed on demand.
+
+_Note that Graywater does not have built-in support for Dagger 2._
+
+### Lazy Loading Binders
+
+Normally, when an item is added to the adapter, the corresponding an `ItemBinder` is loaded as well as all the necessary `Binder` classes.
+
+```
+ Binders             ItemBinders                Items             Screen  
++--------+          +------------+          +-----------+       +--------+
+| Photo  | -------- |            |       /- | TextPost  |       | Header |
++--------+    /---- | Photo Post | -\   /   +-----------+       +--------+
+| Footer | --x /--- |            |   \----- | PhotoPost |       |        |
++--------+    x     +------------+    /     +-----------+       |        |
+| Header | --x \--- |            | --/   /- | TextPost  |       | Text   |
++--------+    \---- | Text Post  |      /   +-----------+       |        |
+| Text   | -------- |            | ----/                        |        |
++--------+          +------------+                              +--------+
+```
+
+But on-screen, only the first item is visible, and out of the first item, only two components are visible. So in the above example, there is no need to load the "Footer" binder. This is what `List<Provider<Binder>>` facilitates.
+
+```
+ Binders             ItemBinders                Items             Screen  
++--------+          +------------+          +-----------+       +--------+
+| Photo  |          |            |      /-- | TextPost  | -x--- | Header |
++--------+          | Photo Post |     /    +-----------+   \   +--------+
+| Footer |          |            |    /     | PhotoPost |    \- |        |
++--------+          +------------+   /      +-----------+       |        |
+| Header | ---\     |            | -/       | TextPost  |       | Text   |
++--------+     \--- | Text Post  |          +-----------+       |        |
+| Text   | -------- |            |                              |        |
++--------+          +------------+                              +--------+
+```
+
+This is very useful for improving initialization performance when loading long cached lists by deferring binder creation until the binder is nearly on screen.
 
 ## How do you use it?
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,23 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'junit:junit:4.12'
+
+    implementation project(path: ':graywater')
+
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:recyclerview-v7:26.1.0'
-    implementation project(path: ':graywater')
+    implementation('com.google.dagger:dagger:2.13') {
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
+    implementation('com.google.dagger:dagger-android:2.13') {
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
+    implementation('com.google.dagger:dagger-android-support:2.13') {
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
+
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.13'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.13'
+
+    testImplementation 'junit:junit:4.12'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest package="com.tumblr.example"
 	xmlns:android="http://schemas.android.com/apk/res/android">
 
-	<application android:allowBackup="true"
+	<application android:name=".App"
+		android:allowBackup="true"
 		android:icon="@mipmap/ic_launcher"
 		android:label="@string/app_name"
 		android:supportsRtl="true"

--- a/app/src/main/java/com/tumblr/example/App.java
+++ b/app/src/main/java/com/tumblr/example/App.java
@@ -1,0 +1,15 @@
+package com.tumblr.example;
+
+import com.tumblr.example.dagger.DaggerAppComponent;
+import dagger.android.AndroidInjector;
+import dagger.android.DaggerApplication;
+
+/**
+ * Created by ericleong on 12/6/17.
+ */
+public class App extends DaggerApplication {
+	@Override
+	protected AndroidInjector<App> applicationInjector() {
+		return DaggerAppComponent.builder().create(this);
+	}
+}

--- a/app/src/main/java/com/tumblr/example/MainActivity.java
+++ b/app/src/main/java/com/tumblr/example/MainActivity.java
@@ -1,15 +1,20 @@
 package com.tumblr.example;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import com.tumblr.example.model.ColorNamePrimitive;
 import com.tumblr.example.model.Palette;
 import com.tumblr.example.model.Primitive;
+import dagger.android.support.DaggerAppCompatActivity;
 
-public class MainActivity extends AppCompatActivity {
+import javax.inject.Inject;
+
+public class MainActivity extends DaggerAppCompatActivity {
+
+	@Inject
+	PrimitiveAdapter mPrimitiveAdapter;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -22,60 +27,58 @@ public class MainActivity extends AppCompatActivity {
 			recyclerView.setLayoutManager(new LinearLayoutManager(this));
 			recyclerView.setItemAnimator(new DefaultItemAnimator());
 
-			final PrimitiveAdapter adapter = new PrimitiveAdapter();
-
 			// A header has nothing special
-			adapter.add(new Primitive.Header());
+			mPrimitiveAdapter.add(new Primitive.Header());
 
 			// Reds
-			adapter.add(new ColorNamePrimitive(R.color.red_base_variant_0, "dark red"));
-			adapter.add(new ColorNamePrimitive(R.color.red_base_variant_1, "red"));
-			adapter.add(new ColorNamePrimitive(R.color.red_base_variant_2, "bright red"));
-			adapter.add(new ColorNamePrimitive(R.color.red_base_variant_3, "shy red"));
-			adapter.add(new ColorNamePrimitive(R.color.red_base_variant_4, "embarrassed red"));
-			adapter.add(new Palette("Red Palette", R.color.red_base_variant_0, R.color.red_base_variant_2, R.color.red_base_variant_4));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.red_base_variant_0, "dark red"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.red_base_variant_1, "red"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.red_base_variant_2, "bright red"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.red_base_variant_3, "shy red"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.red_base_variant_4, "embarrassed red"));
+			mPrimitiveAdapter.add(new Palette("Red Palette", R.color.red_base_variant_0, R.color.red_base_variant_2, R.color.red_base_variant_4));
 
-			adapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_0, "dark yellow"));
-			adapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_1, "yellow"));
-			adapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_2, "bright yellow"));
-			adapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_3, "shy yellow"));
-			adapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_4, "embarrassed yellow"));
-			adapter.add(new Palette("Yellow Palette",
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_0, "dark yellow"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_1, "yellow"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_2, "bright yellow"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_3, "shy yellow"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.yellow_base_variant_4, "embarrassed yellow"));
+			mPrimitiveAdapter.add(new Palette("Yellow Palette",
 					R.color.yellow_base_variant_0, R.color.yellow_base_variant_2, R.color.yellow_base_variant_4));
 
-			adapter.add(new ColorNamePrimitive(R.color.green_base_variant_0, "dark green"));
-			adapter.add(new ColorNamePrimitive(R.color.green_base_variant_1, "green"));
-			adapter.add(new ColorNamePrimitive(R.color.green_base_variant_2, "bright green"));
-			adapter.add(new ColorNamePrimitive(R.color.green_base_variant_3, "shy green"));
-			adapter.add(new ColorNamePrimitive(R.color.green_base_variant_4, "embarrassed green"));
-			adapter.add(new Palette("Green Palette",
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.green_base_variant_0, "dark green"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.green_base_variant_1, "green"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.green_base_variant_2, "bright green"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.green_base_variant_3, "shy green"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.green_base_variant_4, "embarrassed green"));
+			mPrimitiveAdapter.add(new Palette("Green Palette",
 							R.color.green_base_variant_0, R.color.green_base_variant_2, R.color.green_base_variant_4));
 
-			adapter.add(new ColorNamePrimitive(R.color.blue_base_variant_0, "dark blue"));
-			adapter.add(new ColorNamePrimitive(R.color.blue_base_variant_1, "blue"));
-			adapter.add(new ColorNamePrimitive(R.color.blue_base_variant_2, "bright blue"));
-			adapter.add(new ColorNamePrimitive(R.color.blue_base_variant_3, "shy blue"));
-			adapter.add(new ColorNamePrimitive(R.color.blue_base_variant_4, "embarrassed blue"));
-			adapter.add(new Palette("Blue Palette",
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.blue_base_variant_0, "dark blue"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.blue_base_variant_1, "blue"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.blue_base_variant_2, "bright blue"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.blue_base_variant_3, "shy blue"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.blue_base_variant_4, "embarrassed blue"));
+			mPrimitiveAdapter.add(new Palette("Blue Palette",
 							R.color.blue_base_variant_0, R.color.blue_base_variant_2, R.color.blue_base_variant_4));
 
-			adapter.add(new ColorNamePrimitive(R.color.purple_base_variant_0, "dark purple"));
-			adapter.add(new ColorNamePrimitive(R.color.purple_base_variant_1, "purple"));
-			adapter.add(new ColorNamePrimitive(R.color.purple_base_variant_2, "bright purple"));
-			adapter.add(new ColorNamePrimitive(R.color.purple_base_variant_3, "shy purple"));
-			adapter.add(new ColorNamePrimitive(R.color.purple_base_variant_4, "embarrassed purple"));
-			adapter.add(new Palette("Purple Palette",
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.purple_base_variant_0, "dark purple"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.purple_base_variant_1, "purple"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.purple_base_variant_2, "bright purple"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.purple_base_variant_3, "shy purple"));
+			mPrimitiveAdapter.add(new ColorNamePrimitive(R.color.purple_base_variant_4, "embarrassed purple"));
+			mPrimitiveAdapter.add(new Palette("Purple Palette",
 							R.color.purple_base_variant_0, R.color.purple_base_variant_2, R.color.purple_base_variant_4));
 
-			adapter.add(new Palette("Rainbow",
+			mPrimitiveAdapter.add(new Palette("Rainbow",
 							R.color.red_base_variant_0, R.color.yellow_base_variant_0, R.color.green_base_variant_0,
 							R.color.blue_base_variant_0, R.color.purple_base_variant_0));
 
-			adapter.add(new Palette("Strange Rainbow",
+			mPrimitiveAdapter.add(new Palette("Strange Rainbow",
 					R.color.red_base_variant_0, R.color.yellow_base_variant_1, R.color.green_base_variant_2,
 					R.color.blue_base_variant_3, R.color.purple_base_variant_4));
 
-			recyclerView.setAdapter(adapter);
+			recyclerView.setAdapter(mPrimitiveAdapter);
 		}
 	}
 }

--- a/app/src/main/java/com/tumblr/example/PrimitiveAdapter.java
+++ b/app/src/main/java/com/tumblr/example/PrimitiveAdapter.java
@@ -1,5 +1,6 @@
 package com.tumblr.example;
 
+import android.support.annotation.NonNull;
 import com.tumblr.example.binder.ColorNameToastBinder;
 import com.tumblr.example.binder.HeaderBinder;
 import com.tumblr.example.binder.PaletteColorBinder;
@@ -19,6 +20,8 @@ import com.tumblr.example.viewholdercreator.HeaderViewHolderCreator;
 import com.tumblr.example.viewholdercreator.TextPrimitiveViewHolderCreator;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Provider;
+
 /**
  * Created by ericleong on 3/13/16.
  */
@@ -34,26 +37,52 @@ public class PrimitiveAdapter extends GraywaterAdapter<
 		register(new ColorPrimitiveViewHolderCreator(), ColorPrimitiveViewHolder.class);
 
 		// A ColorNamePrimitive is composed of a string and a single color
-		final TextPrimitiveBinder<ColorNamePrimitive> colorNameTextBinder = new TextPrimitiveBinder<>();
-		final ColorNameToastBinder colorNameToastBinder = new ColorNameToastBinder();
+		final Provider<TextPrimitiveBinder<ColorNamePrimitive>> colorNameTextBinder = new Provider<TextPrimitiveBinder<ColorNamePrimitive>>() {
+			@Override
+			public TextPrimitiveBinder<ColorNamePrimitive> get() {
+				return new TextPrimitiveBinder<>();
+			}
+		};
+		final Provider<ColorNameToastBinder> colorNameToastBinder = new Provider<ColorNameToastBinder>() {
+			@Override
+			public ColorNameToastBinder get() {
+				return new ColorNameToastBinder();
+			}
+		};
 
 		final ColorNamePrimitiveItemBinder colorNamePrimitiveItemBinder =
 				new ColorNamePrimitiveItemBinder(this, colorNameTextBinder, colorNameToastBinder);
 		register(ColorNamePrimitive.class, colorNamePrimitiveItemBinder, colorNamePrimitiveItemBinder);
 
 		// A header always displays the same text
-		final HeaderBinder headerBinder = new HeaderBinder();
+		final Provider<HeaderBinder> headerBinder = new Provider<HeaderBinder>() {
+			@Override
+			public HeaderBinder get() {
+				return new HeaderBinder();
+			}
+		};
 		register(Primitive.Header.class, new HeaderPrimitiveItemBinder(headerBinder), null);
 
 		// A palette is composed of a string and a variable number of colors
-		final TextPrimitiveBinder<Palette> paletteTextPrimitiveBinder = new TextPrimitiveBinder<>();
-		final PaletteColorBinder paletteColorBinder = new PaletteColorBinder();
+		final Provider<TextPrimitiveBinder<Palette>> paletteTextPrimitiveBinder = new Provider<TextPrimitiveBinder<Palette>>() {
+			@Override
+			public TextPrimitiveBinder<Palette> get() {
+				return new TextPrimitiveBinder<>();
+			}
+		};
+		final Provider<PaletteColorBinder> paletteColorBinder = new Provider<PaletteColorBinder>() {
+			@Override
+			public PaletteColorBinder get() {
+				return new PaletteColorBinder();
+			}
+		};
 
 		final PaletteItemBinder paletteBinderList =
 				new PaletteItemBinder(paletteTextPrimitiveBinder, paletteColorBinder);
 		register(Palette.class, paletteBinderList, paletteBinderList);
 	}
 
+	@NonNull
 	@Override
 	protected Class<? extends Primitive> getModelType(final Primitive model) {
 		return model.getClass();

--- a/app/src/main/java/com/tumblr/example/PrimitiveAdapter.java
+++ b/app/src/main/java/com/tumblr/example/PrimitiveAdapter.java
@@ -1,85 +1,83 @@
 package com.tumblr.example;
 
 import android.support.annotation.NonNull;
-import com.tumblr.example.binder.ColorNameToastBinder;
-import com.tumblr.example.binder.HeaderBinder;
-import com.tumblr.example.binder.PaletteColorBinder;
-import com.tumblr.example.binder.TextPrimitiveBinder;
-import com.tumblr.example.binderlist.ColorNamePrimitiveItemBinder;
-import com.tumblr.example.binderlist.HeaderPrimitiveItemBinder;
-import com.tumblr.example.binderlist.PaletteItemBinder;
-import com.tumblr.example.model.ColorNamePrimitive;
-import com.tumblr.example.model.Palette;
+import android.support.annotation.Nullable;
+import com.tumblr.example.dagger.PerActivity;
 import com.tumblr.example.model.Primitive;
-import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
-import com.tumblr.example.viewholder.HeaderViewHolder;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
-import com.tumblr.example.viewholder.TextPrimitiveViewHolder;
-import com.tumblr.example.viewholdercreator.ColorPrimitiveViewHolderCreator;
-import com.tumblr.example.viewholdercreator.HeaderViewHolderCreator;
-import com.tumblr.example.viewholdercreator.TextPrimitiveViewHolderCreator;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
+import java.util.Map;
 
 /**
+ * Example adapter.
+ * <p>
  * Created by ericleong on 3/13/16.
  */
+@PerActivity
 public class PrimitiveAdapter extends GraywaterAdapter<
 		Primitive,
 		PrimitiveViewHolder,
 		GraywaterAdapter.Binder<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>,
 		Class<? extends Primitive>> {
 
-	public PrimitiveAdapter() {
-		register(new TextPrimitiveViewHolderCreator(), TextPrimitiveViewHolder.class);
-		register(new HeaderViewHolderCreator(), HeaderViewHolder.class);
-		register(new ColorPrimitiveViewHolderCreator(), ColorPrimitiveViewHolder.class);
+	@NonNull
+	private final Map<Class<? extends Primitive>,
+			Provider<ItemBinder<
+					? extends Primitive,
+					? extends PrimitiveViewHolder,
+					? extends Binder<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>>> mItemBinderMap;
 
-		// A ColorNamePrimitive is composed of a string and a single color
-		final Provider<TextPrimitiveBinder<ColorNamePrimitive>> colorNameTextBinder = new Provider<TextPrimitiveBinder<ColorNamePrimitive>>() {
-			@Override
-			public TextPrimitiveBinder<ColorNamePrimitive> get() {
-				return new TextPrimitiveBinder<>();
-			}
-		};
-		final Provider<ColorNameToastBinder> colorNameToastBinder = new Provider<ColorNameToastBinder>() {
-			@Override
-			public ColorNameToastBinder get() {
-				return new ColorNameToastBinder();
-			}
-		};
+	@NonNull
+	private final Map<Class<? extends Primitive>,
+			Provider<GraywaterAdapter.ActionListener<? extends Primitive,
+					PrimitiveViewHolder,
+					? extends PrimitiveViewHolder>>> mActionListenerMap;
 
-		final ColorNamePrimitiveItemBinder colorNamePrimitiveItemBinder =
-				new ColorNamePrimitiveItemBinder(this, colorNameTextBinder, colorNameToastBinder);
-		register(ColorNamePrimitive.class, colorNamePrimitiveItemBinder, colorNamePrimitiveItemBinder);
+	@Inject
+	public PrimitiveAdapter(final Map<Class<? extends PrimitiveViewHolder>, ViewHolderCreator> viewHolderCreatorMapClass,
+	                        @NonNull final Map<Class<? extends Primitive>,
+			                        Provider<ItemBinder<
+					                        ? extends Primitive,
+					                        ? extends PrimitiveViewHolder,
+					                        ? extends Binder<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>>>
+			                        itemBinderMap,
+	                        @NonNull final Map<Class<? extends Primitive>,
+			                        Provider<GraywaterAdapter.ActionListener<
+					                        ? extends Primitive,
+					                        PrimitiveViewHolder,
+					                        ? extends PrimitiveViewHolder>>> actionListenerMap) {
 
-		// A header always displays the same text
-		final Provider<HeaderBinder> headerBinder = new Provider<HeaderBinder>() {
-			@Override
-			public HeaderBinder get() {
-				return new HeaderBinder();
-			}
-		};
-		register(Primitive.Header.class, new HeaderPrimitiveItemBinder(headerBinder), null);
+		for (Map.Entry<Class<? extends PrimitiveViewHolder>, ViewHolderCreator> entry : viewHolderCreatorMapClass.entrySet()) {
+			register(entry.getValue(), entry.getKey());
+		}
 
-		// A palette is composed of a string and a variable number of colors
-		final Provider<TextPrimitiveBinder<Palette>> paletteTextPrimitiveBinder = new Provider<TextPrimitiveBinder<Palette>>() {
-			@Override
-			public TextPrimitiveBinder<Palette> get() {
-				return new TextPrimitiveBinder<>();
-			}
-		};
-		final Provider<PaletteColorBinder> paletteColorBinder = new Provider<PaletteColorBinder>() {
-			@Override
-			public PaletteColorBinder get() {
-				return new PaletteColorBinder();
-			}
-		};
+		mItemBinderMap = itemBinderMap;
+		mActionListenerMap = actionListenerMap;
+	}
 
-		final PaletteItemBinder paletteBinderList =
-				new PaletteItemBinder(paletteTextPrimitiveBinder, paletteColorBinder);
-		register(Palette.class, paletteBinderList, paletteBinderList);
+	@Nullable
+	@Override
+	protected ItemBinder<? extends Primitive,
+			? extends PrimitiveViewHolder,
+			? extends Binder<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	getItemBinder(final Primitive model) {
+		final Class<? extends Primitive> modelType = getModelType(model);
+
+		return mItemBinderMap.get(modelType).get();
+	}
+
+	@Nullable
+	@Override
+	protected ActionListener<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>
+	getActionListener(final Primitive model) {
+		final Class<? extends Primitive> modelType = getModelType(model);
+		final Provider<ActionListener<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+				provider = mActionListenerMap.get(modelType);
+
+		return provider != null ? provider.get() : null;
 	}
 
 	@NonNull

--- a/app/src/main/java/com/tumblr/example/binder/ColorNameToastBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/ColorNameToastBinder.java
@@ -7,6 +7,7 @@ import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Provider;
 import java.util.List;
 
 /**
@@ -21,8 +22,8 @@ public class ColorNameToastBinder implements GraywaterAdapter.Binder<ColorNamePr
 
 	@Override
 	public void prepare(@NonNull final ColorNamePrimitive model,
-	                    @NonNull final List<GraywaterAdapter.Binder<
-			                    ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                    final List<Provider<GraywaterAdapter.Binder<
+			                    ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                    final int binderIndex) {
 
 	}
@@ -30,13 +31,13 @@ public class ColorNameToastBinder implements GraywaterAdapter.Binder<ColorNamePr
 	@Override
 	public void bind(@NonNull final ColorNamePrimitive model,
 	                 @NonNull final ColorPrimitiveViewHolder holder,
-	                 @NonNull final List<GraywaterAdapter.Binder<
-			                 ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                 @NonNull final List<Provider<GraywaterAdapter.Binder<
+			                 ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                 final int binderIndex,
 	                 @NonNull final GraywaterAdapter.ActionListener<
 			                 ColorNamePrimitive, PrimitiveViewHolder, ColorPrimitiveViewHolder> actionListener) {
 		holder.getView().setBackgroundColor(holder.getView().getResources().getColor(model.getColor()));
-		holder.getActionListenerDelegate().update(actionListener, model, holder, binders, binderIndex, null);
+		holder.getActionListenerDelegate().update(actionListener, model, holder, binderList, binderIndex, null);
 		holder.getView().setOnClickListener(holder.getActionListenerDelegate());
 	}
 

--- a/app/src/main/java/com/tumblr/example/binder/ColorNameToastBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/ColorNameToastBinder.java
@@ -1,19 +1,26 @@
 package com.tumblr.example.binder;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import com.tumblr.example.R;
 import com.tumblr.example.model.ColorNamePrimitive;
 import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.List;
 
 /**
  * Created by ericleong on 3/24/16.
  */
-public class ColorNameToastBinder implements GraywaterAdapter.Binder<ColorNamePrimitive,PrimitiveViewHolder,ColorPrimitiveViewHolder> {
+public class ColorNameToastBinder implements GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ColorPrimitiveViewHolder> {
+
+	@Inject
+	public ColorNameToastBinder() {
+
+	}
 
 	@Override
 	public int getViewType(final ColorNamePrimitive model) {
@@ -34,7 +41,7 @@ public class ColorNameToastBinder implements GraywaterAdapter.Binder<ColorNamePr
 	                 @NonNull final List<Provider<GraywaterAdapter.Binder<
 			                 ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                 final int binderIndex,
-	                 @NonNull final GraywaterAdapter.ActionListener<
+	                 @Nullable final GraywaterAdapter.ActionListener<
 			                 ColorNamePrimitive, PrimitiveViewHolder, ColorPrimitiveViewHolder> actionListener) {
 		holder.getView().setBackgroundColor(holder.getView().getResources().getColor(model.getColor()));
 		holder.getActionListenerDelegate().update(actionListener, model, holder, binderList, binderIndex, null);

--- a/app/src/main/java/com/tumblr/example/binder/HeaderBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/HeaderBinder.java
@@ -1,19 +1,26 @@
 package com.tumblr.example.binder;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import com.tumblr.example.R;
 import com.tumblr.example.model.Primitive;
 import com.tumblr.example.viewholder.HeaderViewHolder;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.List;
 
 /**
  * Created by ericleong on 3/13/16.
  */
-public class HeaderBinder implements GraywaterAdapter.Binder<Primitive.Header,PrimitiveViewHolder,HeaderViewHolder> {
+public class HeaderBinder implements GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, HeaderViewHolder> {
+
+	@Inject
+	public HeaderBinder() {
+
+	}
 
 	@Override
 	public int getViewType(final Primitive.Header model) {
@@ -34,7 +41,7 @@ public class HeaderBinder implements GraywaterAdapter.Binder<Primitive.Header,Pr
 	                 @NonNull final List<Provider<GraywaterAdapter.Binder<
 			                 ? super Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                 final int binderIndex,
-	                 @NonNull final GraywaterAdapter.ActionListener<
+	                 @Nullable final GraywaterAdapter.ActionListener<
 			                 Primitive.Header, PrimitiveViewHolder, HeaderViewHolder> actionListener) {
 
 	}

--- a/app/src/main/java/com/tumblr/example/binder/HeaderBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/HeaderBinder.java
@@ -7,6 +7,7 @@ import com.tumblr.example.viewholder.HeaderViewHolder;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Provider;
 import java.util.List;
 
 /**
@@ -21,8 +22,8 @@ public class HeaderBinder implements GraywaterAdapter.Binder<Primitive.Header,Pr
 
 	@Override
 	public void prepare(@NonNull final Primitive.Header model,
-	                    @NonNull final List<GraywaterAdapter.Binder<
-			                    ? super Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                    final List<Provider<GraywaterAdapter.Binder<
+			                    ? super Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                    final int binderIndex) {
 
 	}
@@ -30,8 +31,8 @@ public class HeaderBinder implements GraywaterAdapter.Binder<Primitive.Header,Pr
 	@Override
 	public void bind(@NonNull final Primitive.Header model,
 	                 @NonNull final HeaderViewHolder holder,
-	                 @NonNull final List<GraywaterAdapter.Binder<
-			                 ? super Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                 @NonNull final List<Provider<GraywaterAdapter.Binder<
+			                 ? super Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                 final int binderIndex,
 	                 @NonNull final GraywaterAdapter.ActionListener<
 			                 Primitive.Header, PrimitiveViewHolder, HeaderViewHolder> actionListener) {

--- a/app/src/main/java/com/tumblr/example/binder/PaletteColorBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/PaletteColorBinder.java
@@ -1,6 +1,7 @@
 package com.tumblr.example.binder;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.Toast;
 import com.tumblr.example.R;
@@ -9,13 +10,19 @@ import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.List;
 
 /**
  * Created by ericleong on 3/13/16.
  */
-public class PaletteColorBinder implements GraywaterAdapter.Binder<Palette,PrimitiveViewHolder,ColorPrimitiveViewHolder> {
+public class PaletteColorBinder implements GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ColorPrimitiveViewHolder> {
+
+	@Inject
+	public PaletteColorBinder() {
+
+	}
 
 	@Override
 	public int getViewType(final Palette model) {
@@ -36,7 +43,7 @@ public class PaletteColorBinder implements GraywaterAdapter.Binder<Palette,Primi
 	                 @NonNull final List<Provider<GraywaterAdapter.Binder<
 			                 ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                 final int binderIndex,
-	                 @NonNull final GraywaterAdapter.ActionListener<
+	                 @Nullable final GraywaterAdapter.ActionListener<
 			                 Palette, PrimitiveViewHolder, ColorPrimitiveViewHolder> actionListener) {
 		holder.getView().setBackgroundColor(holder.getView().getResources().getColor(model.getColors().get
 				(binderIndex - 1)));

--- a/app/src/main/java/com/tumblr/example/binder/PaletteColorBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/PaletteColorBinder.java
@@ -9,6 +9,7 @@ import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Provider;
 import java.util.List;
 
 /**
@@ -23,8 +24,8 @@ public class PaletteColorBinder implements GraywaterAdapter.Binder<Palette,Primi
 
 	@Override
 	public void prepare(@NonNull final Palette model,
-	                    @NonNull final List<GraywaterAdapter.Binder<
-			                    ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                    final List<Provider<GraywaterAdapter.Binder<
+			                    ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                    final int binderIndex) {
 
 	}
@@ -32,8 +33,8 @@ public class PaletteColorBinder implements GraywaterAdapter.Binder<Palette,Primi
 	@Override
 	public void bind(@NonNull final Palette model,
 	                 @NonNull final ColorPrimitiveViewHolder holder,
-	                 @NonNull final List<GraywaterAdapter.Binder<
-			                 ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                 @NonNull final List<Provider<GraywaterAdapter.Binder<
+			                 ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                 final int binderIndex,
 	                 @NonNull final GraywaterAdapter.ActionListener<
 			                 Palette, PrimitiveViewHolder, ColorPrimitiveViewHolder> actionListener) {

--- a/app/src/main/java/com/tumblr/example/binder/TextPrimitiveBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/TextPrimitiveBinder.java
@@ -7,6 +7,7 @@ import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.example.viewholder.TextPrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Provider;
 import java.util.List;
 
 /**
@@ -21,8 +22,8 @@ public class TextPrimitiveBinder<T extends Primitive.Text>
 
 	@Override
 	public void prepare(@NonNull final T model,
-	                    @NonNull final List<GraywaterAdapter.Binder<
-			                    ? super T, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                    final List<Provider<GraywaterAdapter.Binder<
+			                    ? super T, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                    final int binderIndex) {
 
 	}
@@ -30,7 +31,8 @@ public class TextPrimitiveBinder<T extends Primitive.Text>
 	@Override
 	public void bind(@NonNull final T model,
 	                 @NonNull final TextPrimitiveViewHolder holder,
-	                 @NonNull final List<GraywaterAdapter.Binder<? super T, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                 @NonNull final List<Provider<GraywaterAdapter.Binder<
+			                 ? super T, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                 final int binderIndex,
 	                 @NonNull final GraywaterAdapter.ActionListener<T, PrimitiveViewHolder, TextPrimitiveViewHolder> actionListener) {
 		holder.getTextView().setText(model.getString());

--- a/app/src/main/java/com/tumblr/example/binder/TextPrimitiveBinder.java
+++ b/app/src/main/java/com/tumblr/example/binder/TextPrimitiveBinder.java
@@ -1,12 +1,14 @@
 package com.tumblr.example.binder;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import com.tumblr.example.R;
 import com.tumblr.example.model.Primitive;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.example.viewholder.TextPrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.List;
 
@@ -15,6 +17,12 @@ import java.util.List;
  */
 public class TextPrimitiveBinder<T extends Primitive.Text>
 		implements GraywaterAdapter.Binder<T,PrimitiveViewHolder,TextPrimitiveViewHolder> {
+
+	@Inject
+	public TextPrimitiveBinder() {
+
+	}
+
 	@Override
 	public int getViewType(final T model) {
 		return R.layout.item_text;
@@ -34,7 +42,7 @@ public class TextPrimitiveBinder<T extends Primitive.Text>
 	                 @NonNull final List<Provider<GraywaterAdapter.Binder<
 			                 ? super T, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                 final int binderIndex,
-	                 @NonNull final GraywaterAdapter.ActionListener<T, PrimitiveViewHolder, TextPrimitiveViewHolder> actionListener) {
+	                 @Nullable final GraywaterAdapter.ActionListener<T, PrimitiveViewHolder, TextPrimitiveViewHolder> actionListener) {
 		holder.getTextView().setText(model.getString());
 	}
 

--- a/app/src/main/java/com/tumblr/example/binderlist/ColorNamePrimitiveItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/ColorNamePrimitiveItemBinder.java
@@ -7,10 +7,12 @@ import android.widget.Toast;
 import com.tumblr.example.PrimitiveAdapter;
 import com.tumblr.example.binder.ColorNameToastBinder;
 import com.tumblr.example.binder.TextPrimitiveBinder;
+import com.tumblr.example.dagger.PerActivity;
 import com.tumblr.example.model.ColorNamePrimitive;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,7 @@ import java.util.List;
 /**
  * Created by ericleong on 3/28/16.
  */
+@PerActivity
 public class ColorNamePrimitiveItemBinder
 		implements GraywaterAdapter.ItemBinder<ColorNamePrimitive, PrimitiveViewHolder,
 		GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>,
@@ -26,9 +29,10 @@ public class ColorNamePrimitiveItemBinder
 	private final Provider<TextPrimitiveBinder<ColorNamePrimitive>> mColorNameTextBinder;
 	private final Provider<ColorNameToastBinder> mColorNameToastBinder;
 
-	private final PrimitiveAdapter mAdapter;
+	private final Provider<PrimitiveAdapter> mAdapter;
 
-	public ColorNamePrimitiveItemBinder(final PrimitiveAdapter adapter,
+	@Inject
+	public ColorNamePrimitiveItemBinder(final Provider<PrimitiveAdapter> adapter,
 	                                    final Provider<TextPrimitiveBinder<ColorNamePrimitive>> colorNameTextBinder,
 	                                    final Provider<ColorNameToastBinder> colorNameToastBinder) {
 		mColorNameTextBinder = colorNameTextBinder;
@@ -57,7 +61,9 @@ public class ColorNamePrimitiveItemBinder
 	                @Nullable final Object obj) {
 		Toast.makeText(v.getContext(), model.getString(), Toast.LENGTH_SHORT).show();
 
-		mAdapter.add(mAdapter.getItemPosition(holder.getAdapterPosition()) + 1,
+		final PrimitiveAdapter adapter = mAdapter.get();
+
+		adapter.add(adapter.getItemPosition(holder.getAdapterPosition()) + 1,
 				new ColorNamePrimitive(model.getColor(), model.getString() + "+"), true);
 	}
 }

--- a/app/src/main/java/com/tumblr/example/binderlist/ColorNamePrimitiveItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/ColorNamePrimitiveItemBinder.java
@@ -11,6 +11,7 @@ import com.tumblr.example.model.ColorNamePrimitive;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,14 +23,14 @@ public class ColorNamePrimitiveItemBinder
 		GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>,
 		GraywaterAdapter.ActionListener<ColorNamePrimitive, PrimitiveViewHolder, PrimitiveViewHolder> {
 
-	private final TextPrimitiveBinder<ColorNamePrimitive> mColorNameTextBinder;
-	private final ColorNameToastBinder mColorNameToastBinder;
+	private final Provider<TextPrimitiveBinder<ColorNamePrimitive>> mColorNameTextBinder;
+	private final Provider<ColorNameToastBinder> mColorNameToastBinder;
 
 	private final PrimitiveAdapter mAdapter;
 
 	public ColorNamePrimitiveItemBinder(final PrimitiveAdapter adapter,
-	                                    final TextPrimitiveBinder<ColorNamePrimitive> colorNameTextBinder,
-	                                    final ColorNameToastBinder colorNameToastBinder) {
+	                                    final Provider<TextPrimitiveBinder<ColorNamePrimitive>> colorNameTextBinder,
+	                                    final Provider<ColorNameToastBinder> colorNameToastBinder) {
 		mColorNameTextBinder = colorNameTextBinder;
 		mColorNameToastBinder = colorNameToastBinder;
 		mAdapter = adapter;
@@ -37,9 +38,10 @@ public class ColorNamePrimitiveItemBinder
 
 	@NonNull
 	@Override
-	public List<GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	public List<Provider<? extends GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>>
 	getBinderList(@NonNull final ColorNamePrimitive model, final int position) {
-		return new ArrayList<GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>() {{
+		return new ArrayList<Provider<
+				? extends GraywaterAdapter.Binder<ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>>() {{
 			add(mColorNameTextBinder);
 			add(mColorNameToastBinder);
 		}};
@@ -49,8 +51,8 @@ public class ColorNamePrimitiveItemBinder
 	public void act(@NonNull final ColorNamePrimitive model,
 	                @NonNull final PrimitiveViewHolder holder,
 	                @NonNull final View v,
-	                @NonNull final List<GraywaterAdapter.Binder<
-			                ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                @NonNull final List<Provider<GraywaterAdapter.Binder<
+			                ? super ColorNamePrimitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                final int binderIndex,
 	                @Nullable final Object obj) {
 		Toast.makeText(v.getContext(), model.getString(), Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/tumblr/example/binderlist/HeaderPrimitiveItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/HeaderPrimitiveItemBinder.java
@@ -2,10 +2,12 @@ package com.tumblr.example.binderlist;
 
 import android.support.annotation.NonNull;
 import com.tumblr.example.binder.HeaderBinder;
+import com.tumblr.example.dagger.PerActivity;
 import com.tumblr.example.model.Primitive;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,11 +15,13 @@ import java.util.List;
 /**
  * Created by ericleong on 3/28/16.
  */
+@PerActivity
 public class HeaderPrimitiveItemBinder implements
 		GraywaterAdapter.ItemBinder<Primitive.Header, PrimitiveViewHolder,
 				GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> {
 	private final Provider<HeaderBinder> mHeaderBinder;
 
+	@Inject
 	public HeaderPrimitiveItemBinder(final Provider<HeaderBinder> headerBinder) {
 		mHeaderBinder = headerBinder;
 	}

--- a/app/src/main/java/com/tumblr/example/binderlist/HeaderPrimitiveItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/HeaderPrimitiveItemBinder.java
@@ -6,6 +6,7 @@ import com.tumblr.example.model.Primitive;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,17 +16,19 @@ import java.util.List;
 public class HeaderPrimitiveItemBinder implements
 		GraywaterAdapter.ItemBinder<Primitive.Header, PrimitiveViewHolder,
 				GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> {
-	private final HeaderBinder mHeaderBinder;
+	private final Provider<HeaderBinder> mHeaderBinder;
 
-	public HeaderPrimitiveItemBinder(final HeaderBinder headerBinder) {
+	public HeaderPrimitiveItemBinder(final Provider<HeaderBinder> headerBinder) {
 		mHeaderBinder = headerBinder;
 	}
 
 	@NonNull
 	@Override
-	public List<GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	public List<Provider<
+			? extends GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>>
 	getBinderList(@NonNull final Primitive.Header model, final int position) {
-		return new ArrayList<GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>() {{
+		return new ArrayList<Provider<
+				? extends GraywaterAdapter.Binder<Primitive.Header, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>>() {{
 			add(mHeaderBinder);
 		}};
 	}

--- a/app/src/main/java/com/tumblr/example/binderlist/PaletteItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/PaletteItemBinder.java
@@ -5,10 +5,12 @@ import android.support.annotation.Nullable;
 import android.view.View;
 import com.tumblr.example.binder.PaletteColorBinder;
 import com.tumblr.example.binder.TextPrimitiveBinder;
+import com.tumblr.example.dagger.PerActivity;
 import com.tumblr.example.model.Palette;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,12 +18,14 @@ import java.util.List;
 /**
  * Created by ericleong on 3/28/16.
  */
+@PerActivity
 public class PaletteItemBinder implements GraywaterAdapter.ItemBinder<Palette, PrimitiveViewHolder,
 		GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>,
 		GraywaterAdapter.ActionListener<Palette, PrimitiveViewHolder, PrimitiveViewHolder> {
 	private final Provider<TextPrimitiveBinder<Palette>> mPaletteTextPrimitiveBinder;
 	private final Provider<PaletteColorBinder> mPaletteColorBinder;
 
+	@Inject
 	public PaletteItemBinder(final Provider<TextPrimitiveBinder<Palette>> paletteTextPrimitiveBinder,
 	                         final Provider<PaletteColorBinder> paletteColorBinder) {
 		mPaletteTextPrimitiveBinder = paletteTextPrimitiveBinder;

--- a/app/src/main/java/com/tumblr/example/binderlist/PaletteItemBinder.java
+++ b/app/src/main/java/com/tumblr/example/binderlist/PaletteItemBinder.java
@@ -9,6 +9,7 @@ import com.tumblr.example.model.Palette;
 import com.tumblr.example.viewholder.PrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,19 +19,20 @@ import java.util.List;
 public class PaletteItemBinder implements GraywaterAdapter.ItemBinder<Palette, PrimitiveViewHolder,
 		GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>,
 		GraywaterAdapter.ActionListener<Palette, PrimitiveViewHolder, PrimitiveViewHolder> {
-	private final TextPrimitiveBinder<Palette> mPaletteTextPrimitiveBinder;
-	private final PaletteColorBinder mPaletteColorBinder;
+	private final Provider<TextPrimitiveBinder<Palette>> mPaletteTextPrimitiveBinder;
+	private final Provider<PaletteColorBinder> mPaletteColorBinder;
 
-	public PaletteItemBinder(final TextPrimitiveBinder<Palette> paletteTextPrimitiveBinder, final PaletteColorBinder paletteColorBinder) {
+	public PaletteItemBinder(final Provider<TextPrimitiveBinder<Palette>> paletteTextPrimitiveBinder,
+	                         final Provider<PaletteColorBinder> paletteColorBinder) {
 		mPaletteTextPrimitiveBinder = paletteTextPrimitiveBinder;
 		mPaletteColorBinder = paletteColorBinder;
 	}
 
 	@NonNull
 	@Override
-	public List<GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	public List<Provider<? extends GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>>
 	getBinderList(@NonNull final Palette model, final int position) {
-		return new ArrayList<GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>() {{
+		return new ArrayList<Provider<? extends GraywaterAdapter.Binder<Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>>() {{
 			add(mPaletteTextPrimitiveBinder);
 
 			for (int color : model.getColors()) {
@@ -43,8 +45,8 @@ public class PaletteItemBinder implements GraywaterAdapter.ItemBinder<Palette, P
 	public void act(@NonNull final Palette model,
 	                @NonNull final PrimitiveViewHolder holder,
 	                @NonNull final View v,
-	                @NonNull final List<GraywaterAdapter.Binder<
-			                ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>> binders,
+	                @NonNull final List<Provider<GraywaterAdapter.Binder<
+			                ? super Palette, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>> binderList,
 	                final int binderIndex,
 	                @Nullable final Object obj) {
 

--- a/app/src/main/java/com/tumblr/example/dagger/AppComponent.java
+++ b/app/src/main/java/com/tumblr/example/dagger/AppComponent.java
@@ -1,0 +1,22 @@
+package com.tumblr.example.dagger;
+
+import com.tumblr.example.App;
+import com.tumblr.example.dagger.module.ActivityBindingModule;
+import dagger.Component;
+import dagger.android.AndroidInjector;
+import dagger.android.support.AndroidSupportInjectionModule;
+
+import javax.inject.Singleton;
+
+/**
+ * Created by ericleong on 12/6/17.
+ */
+@Singleton
+@Component(modules = {
+		AndroidSupportInjectionModule.class,
+		ActivityBindingModule.class
+})
+public interface AppComponent extends AndroidInjector<App> {
+	@Component.Builder
+	abstract class Builder extends AndroidInjector.Builder<App> {}
+}

--- a/app/src/main/java/com/tumblr/example/dagger/PerActivity.java
+++ b/app/src/main/java/com/tumblr/example/dagger/PerActivity.java
@@ -1,0 +1,15 @@
+package com.tumblr.example.dagger;
+
+import javax.inject.Scope;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Activity scope.
+ * <p>
+ * Created by ericleong on 12/6/17.
+ */
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PerActivity {
+}

--- a/app/src/main/java/com/tumblr/example/dagger/key/PrimitiveCreatorKey.java
+++ b/app/src/main/java/com/tumblr/example/dagger/key/PrimitiveCreatorKey.java
@@ -1,0 +1,24 @@
+package com.tumblr.example.dagger.key;
+
+import com.tumblr.example.viewholder.PrimitiveViewHolder;
+import dagger.MapKey;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A {@link MapKey} annotation for maps with {@code Class<? extends PrimitiveViewHolder>} keys.
+ *
+ * Created by ericleong on 12/6/17.
+ */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+@MapKey
+public @interface PrimitiveCreatorKey {
+	Class<? extends PrimitiveViewHolder> value();
+}

--- a/app/src/main/java/com/tumblr/example/dagger/key/PrimitiveItemBinderKey.java
+++ b/app/src/main/java/com/tumblr/example/dagger/key/PrimitiveItemBinderKey.java
@@ -1,0 +1,24 @@
+package com.tumblr.example.dagger.key;
+
+import com.tumblr.example.model.Primitive;
+import dagger.MapKey;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A {@link MapKey} annotation for maps with {@code Class<? extends Primitive>} keys.
+ *
+ * Created by ericleong on 12/6/17.
+ */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+@MapKey
+public @interface PrimitiveItemBinderKey {
+	Class<? extends Primitive> value();
+}

--- a/app/src/main/java/com/tumblr/example/dagger/module/ActionListenerModule.java
+++ b/app/src/main/java/com/tumblr/example/dagger/module/ActionListenerModule.java
@@ -1,0 +1,25 @@
+package com.tumblr.example.dagger.module;
+
+import com.tumblr.example.binderlist.ColorNamePrimitiveItemBinder;
+import com.tumblr.example.dagger.PerActivity;
+import com.tumblr.example.dagger.key.PrimitiveItemBinderKey;
+import com.tumblr.example.model.ColorNamePrimitive;
+import com.tumblr.example.model.Primitive;
+import com.tumblr.example.viewholder.PrimitiveViewHolder;
+import com.tumblr.graywater.GraywaterAdapter;
+import dagger.Binds;
+import dagger.Module;
+import dagger.multibindings.IntoMap;
+
+/**
+ * Created by ericleong on 12/7/17.
+ */
+@Module
+public abstract class ActionListenerModule {
+	@PerActivity
+	@Binds
+	@IntoMap
+	@PrimitiveItemBinderKey(ColorNamePrimitive.class)
+	abstract GraywaterAdapter.ActionListener<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>
+	bindsColorNamePrimitiveActionListener(ColorNamePrimitiveItemBinder colorNamePrimitiveItemBinder);
+}

--- a/app/src/main/java/com/tumblr/example/dagger/module/ActivityBindingModule.java
+++ b/app/src/main/java/com/tumblr/example/dagger/module/ActivityBindingModule.java
@@ -1,0 +1,22 @@
+package com.tumblr.example.dagger.module;
+
+import com.tumblr.example.MainActivity;
+import com.tumblr.example.dagger.PerActivity;
+import dagger.Module;
+import dagger.android.ContributesAndroidInjector;
+
+/**
+ * Created by ericleong on 12/6/17.
+ */
+@Module
+public abstract class ActivityBindingModule {
+	@PerActivity
+	@ContributesAndroidInjector(
+			modules = {
+					ItemBinderModule.class,
+					ViewHolderCreatorModule.class,
+					ActionListenerModule.class
+			}
+	)
+	abstract MainActivity contributeMainActivityInjector();
+}

--- a/app/src/main/java/com/tumblr/example/dagger/module/ItemBinderModule.java
+++ b/app/src/main/java/com/tumblr/example/dagger/module/ItemBinderModule.java
@@ -1,0 +1,51 @@
+package com.tumblr.example.dagger.module;
+
+import com.tumblr.example.binderlist.ColorNamePrimitiveItemBinder;
+import com.tumblr.example.binderlist.HeaderPrimitiveItemBinder;
+import com.tumblr.example.binderlist.PaletteItemBinder;
+import com.tumblr.example.dagger.PerActivity;
+import com.tumblr.example.dagger.key.PrimitiveItemBinderKey;
+import com.tumblr.example.model.ColorNamePrimitive;
+import com.tumblr.example.model.Palette;
+import com.tumblr.example.model.Primitive;
+import com.tumblr.example.viewholder.PrimitiveViewHolder;
+import com.tumblr.graywater.GraywaterAdapter;
+import dagger.Binds;
+import dagger.Module;
+import dagger.multibindings.IntoMap;
+
+/**
+ * Created by ericleong on 12/6/17.
+ */
+@Module
+public abstract class ItemBinderModule {
+	@PerActivity
+	@Binds
+	@IntoMap
+	@PrimitiveItemBinderKey(ColorNamePrimitive.class)
+	abstract GraywaterAdapter.ItemBinder<
+			? extends Primitive,
+			? extends PrimitiveViewHolder,
+			? extends GraywaterAdapter.Binder<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	bindsColorNamePrimitiveItemBinder(ColorNamePrimitiveItemBinder colorNamePrimitiveItemBinder);
+
+	@PerActivity
+	@Binds
+	@IntoMap
+	@PrimitiveItemBinderKey(Primitive.Header.class)
+	abstract GraywaterAdapter.ItemBinder<
+			? extends Primitive,
+			? extends PrimitiveViewHolder,
+			? extends GraywaterAdapter.Binder<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	bindsHeaderPrimitiveItemBinder(HeaderPrimitiveItemBinder headerPrimitiveItemBinder);
+
+	@PerActivity
+	@Binds
+	@IntoMap
+	@PrimitiveItemBinderKey(Palette.class)
+	abstract GraywaterAdapter.ItemBinder<
+			? extends Primitive,
+			? extends PrimitiveViewHolder,
+			? extends GraywaterAdapter.Binder<? extends Primitive, PrimitiveViewHolder, ? extends PrimitiveViewHolder>>
+	bindsPaletteItemBinder(PaletteItemBinder paletteItemBinder);
+}

--- a/app/src/main/java/com/tumblr/example/dagger/module/ViewHolderCreatorModule.java
+++ b/app/src/main/java/com/tumblr/example/dagger/module/ViewHolderCreatorModule.java
@@ -1,0 +1,36 @@
+package com.tumblr.example.dagger.module;
+
+import com.tumblr.example.dagger.key.PrimitiveCreatorKey;
+import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
+import com.tumblr.example.viewholder.HeaderViewHolder;
+import com.tumblr.example.viewholder.TextPrimitiveViewHolder;
+import com.tumblr.example.viewholdercreator.ColorPrimitiveViewHolderCreator;
+import com.tumblr.example.viewholdercreator.HeaderViewHolderCreator;
+import com.tumblr.example.viewholdercreator.TextPrimitiveViewHolderCreator;
+import com.tumblr.graywater.GraywaterAdapter;
+import dagger.Binds;
+import dagger.Module;
+import dagger.multibindings.IntoMap;
+
+/**
+ * Created by ericleong on 12/6/17.
+ */
+@Module
+public abstract class ViewHolderCreatorModule {
+	@Binds
+	@IntoMap
+	@PrimitiveCreatorKey(TextPrimitiveViewHolder.class)
+	abstract GraywaterAdapter.ViewHolderCreator bindsTextPrimitiveViewHolderCreator(
+			TextPrimitiveViewHolderCreator textPrimitiveViewHolderCreator);
+
+	@Binds
+	@IntoMap
+	@PrimitiveCreatorKey(HeaderViewHolder.class)
+	abstract GraywaterAdapter.ViewHolderCreator bindsHeaderViewHolderCreator(HeaderViewHolderCreator headerViewHolderCreator);
+
+	@Binds
+	@IntoMap
+	@PrimitiveCreatorKey(ColorPrimitiveViewHolder.class)
+	abstract GraywaterAdapter.ViewHolderCreator bindsColorPrimitiveViewHolderCreator(
+			ColorPrimitiveViewHolderCreator colorPrimitiveViewHolderCreator);
+}

--- a/app/src/main/java/com/tumblr/example/viewholdercreator/ColorPrimitiveViewHolderCreator.java
+++ b/app/src/main/java/com/tumblr/example/viewholdercreator/ColorPrimitiveViewHolderCreator.java
@@ -6,10 +6,18 @@ import com.tumblr.example.R;
 import com.tumblr.example.viewholder.ColorPrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
+
 /**
  * Created by ericleong on 3/15/16.
  */
 public class ColorPrimitiveViewHolderCreator implements GraywaterAdapter.ViewHolderCreator {
+
+	@Inject
+	public ColorPrimitiveViewHolderCreator() {
+
+	}
+
 	@Override
 	public ColorPrimitiveViewHolder create(final ViewGroup parent) {
 		return new ColorPrimitiveViewHolder(GraywaterAdapter.inflate(parent, R.layout.item_color));

--- a/app/src/main/java/com/tumblr/example/viewholdercreator/HeaderViewHolderCreator.java
+++ b/app/src/main/java/com/tumblr/example/viewholdercreator/HeaderViewHolderCreator.java
@@ -5,10 +5,18 @@ import com.tumblr.example.R;
 import com.tumblr.example.viewholder.HeaderViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
+
 /**
  * Created by ericleong on 3/15/16.
  */
 public class HeaderViewHolderCreator implements GraywaterAdapter.ViewHolderCreator {
+
+	@Inject
+	public HeaderViewHolderCreator() {
+
+	}
+
 	@Override
 	public HeaderViewHolder create(final ViewGroup parent) {
 		return new HeaderViewHolder(GraywaterAdapter.inflate(parent, R.layout.item_header));

--- a/app/src/main/java/com/tumblr/example/viewholdercreator/TextPrimitiveViewHolderCreator.java
+++ b/app/src/main/java/com/tumblr/example/viewholdercreator/TextPrimitiveViewHolderCreator.java
@@ -5,10 +5,18 @@ import com.tumblr.example.R;
 import com.tumblr.example.viewholder.TextPrimitiveViewHolder;
 import com.tumblr.graywater.GraywaterAdapter;
 
+import javax.inject.Inject;
+
 /**
  * Created by ericleong on 3/15/16.
  */
 public class TextPrimitiveViewHolderCreator implements GraywaterAdapter.ViewHolderCreator {
+
+	@Inject
+	public TextPrimitiveViewHolderCreator() {
+
+	}
+
 	@Override
 	public TextPrimitiveViewHolder create(final ViewGroup parent) {
 		return new TextPrimitiveViewHolder(GraywaterAdapter.inflate(parent, R.layout.item_text));

--- a/graywater/build.gradle
+++ b/graywater/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testImplementation'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:3.5"
     api 'com.android.support:recyclerview-v7:26.1.0'
+    api 'javax.inject:javax.inject:1'
 }
 
 checkstyle {

--- a/graywater/src/main/java/com/tumblr/graywater/GraywaterAdapter.java
+++ b/graywater/src/main/java/com/tumblr/graywater/GraywaterAdapter.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -30,9 +31,10 @@ import java.util.Set;
  * @param <VH>
  * 		the viewholder type.
  * @param <B>
- *      the binder type.
+ * 		the binder type.
  * @param <MT>
  * 		the type of the model type ({@code Class<T>} for example)
+ * @see <a href="https://github.tumblr.net/TumblrMobile/android2/blob/master/graywater/README.md">README</a>
  */
 public abstract class GraywaterAdapter<
 		T,
@@ -77,20 +79,19 @@ public abstract class GraywaterAdapter<
 	 * Map from model to an action listener. A model may have multiple action listeners if there are multiple events.
 	 */
 	@NonNull
-	private final Map<MT, ActionListener<? extends T, VH, ? extends VH>> mActionListenerMap
-			= new ArrayMap<>();
+	private final Map<MT, ActionListener<? extends T, VH, ? extends VH>> mActionListenerMap = new ArrayMap<>();
 
 	/**
 	 * Index of the last model that was bound.
 	 */
 	private int mPreviousBoundViewHolderPosition = NO_PREVIOUS_BOUND_VIEWHOLDER;
 
-	private final List<List<Binder<? super T, VH, ? extends VH>>> mBinderListCache = new ArrayList<>();
+	private final List<List<Provider<Binder<? super T, VH, ? extends VH>>>> mBinderListCache = new ArrayList<>();
 	private final List<Integer> mViewHolderToItemPositionCache = new ArrayList<>();
 	private final List<Integer> mItemPositionToFirstViewHolderPositionCache = new ArrayList<>();
 	/**
 	 * The viewholders that have had {@link #prepare(int, Binder, Object, List, int)} called on them.
-	 *
+	 * <p>
 	 * {@link #add(Object)}, {@link #remove(int)}, {@link #onViewRecycled(RecyclerView.ViewHolder)}
 	 * will all cause this to be cleared.
 	 */
@@ -118,7 +119,7 @@ public abstract class GraywaterAdapter<
 	 * 		the listener to associate with the model.
 	 */
 	protected void register(@NonNull final MT modelType,
-	                        @NonNull final ItemBinder<? extends T, VH, ? extends B> parts,
+	                        @NonNull final ItemBinder<? extends T, ? extends VH, ? extends B> parts,
 	                        @Nullable final ActionListener<? extends T, VH, ? extends VH> listener) {
 		mItemBinderMap.put(modelType, parts);
 		mActionListenerMap.put(modelType, listener);
@@ -129,7 +130,28 @@ public abstract class GraywaterAdapter<
 	 * 		the model to get the type of.
 	 * @return the appropriate type (for example, {@link Class<T>}).
 	 */
+	@NonNull
 	protected abstract MT getModelType(T model);
+
+	/**
+	 * @param model
+	 * 		the model to get the {@link ItemBinder} for.
+	 * @return the {@link ItemBinder} for the given model.
+	 */
+	@Nullable
+	protected ItemBinder<? extends T, ? extends VH, ? extends B> getItemBinder(final T model) {
+		return mItemBinderMap.get(getModelType(model));
+	}
+
+	/**
+	 * @param model
+	 * 		the model to get the {@link ItemBinder} for.
+	 * @return the {@link ActionListener} for the given model.
+	 */
+	@Nullable
+	protected ActionListener<? extends T, VH, ? extends VH> getActionListener(final T model) {
+		return mActionListenerMap.get(getModelType(model));
+	}
 
 	/**
 	 * @param model
@@ -139,21 +161,13 @@ public abstract class GraywaterAdapter<
 	 * @return the list of binders to use.
 	 */
 	@Nullable
-	protected List<Binder<? super T, VH, ? extends VH>> getParts(final T model, final int position) {
-		final List<Binder<? super T, VH, ? extends VH>> list;
+	protected List<Provider<Binder<? super T, VH, ? extends VH>>> getParts(final T model, final int position) {
+		final List<Provider<Binder<? super T, VH, ? extends VH>>> list;
 
-		final ItemBinder itemBinder = mItemBinderMap.get(getModelType(model));
+		final ItemBinder itemBinder = getItemBinder(model);
 
 		if (itemBinder != null) {
 			list = itemBinder.getBinderList(model, position);
-
-			for (final Binder<? super T, VH, ? extends VH> binder : list) {
-				if (!mViewHolderCreatorMap.containsKey(binder.getViewType(model))) {
-					throw new IllegalArgumentException("Need to register "
-							+ binder.getViewType(model)
-							+ " before adding a ItemBinder that uses it.");
-				}
-			}
 		} else {
 			list = null;
 		}
@@ -175,7 +189,7 @@ public abstract class GraywaterAdapter<
 
 		final int itemIndex = mViewHolderToItemPositionCache.get(viewHolderPosition);
 		final T item = mItems.get(itemIndex);
-		final List<Binder<? super T, VH, ? extends VH>> binders = mBinderListCache.get(itemIndex);
+		final List<Provider<Binder<? super T, VH, ? extends VH>>> binders = mBinderListCache.get(itemIndex);
 		// index of the first item in the set of viewholders for the current item.
 		final int firstVHPosForItem = mItemPositionToFirstViewHolderPositionCache.get(itemIndex);
 
@@ -194,16 +208,16 @@ public abstract class GraywaterAdapter<
 	 * @param viewHolderPosition
 	 * 		position to query
 	 * @return integer value identifying the type of the view needed to represent the item at
-	 *                 <code>position</code>. Type codes need not be contiguous.
+	 * <code>position</code>. Type codes need not be contiguous.
 	 */
 	protected int internalGetItemViewType(final int viewHolderPosition) {
 		final BinderResult result = computeItemAndBinderIndex(viewHolderPosition);
 
-		final Binder<? super T, VH, ? extends VH> binder = result.getBinder();
+		final Provider<Binder<? super T, VH, ? extends VH>> binder = result.getBinder();
 		final int viewType;
 
 		if (binder != null) {
-			viewType = mViewHolderCreatorMap.get(binder.getViewType(result.item)).getViewType();
+			viewType = getViewHolderCreatorMap().get(binder.get().getViewType(result.item)).getViewType();
 		} else {
 			viewType = -1;
 		}
@@ -220,9 +234,14 @@ public abstract class GraywaterAdapter<
 		return mViewTypeToViewHolderClassMap.get(viewType);
 	}
 
+	@NonNull
+	protected Map<Integer, ViewHolderCreator> getViewHolderCreatorMap() {
+		return mViewHolderCreatorMap;
+	}
+
 	@Override
 	public VH onCreateViewHolder(final ViewGroup parent, final int viewType) {
-		return (VH) mViewHolderCreatorMap.get(viewType).create(parent);
+		return (VH) getViewHolderCreatorMap().get(viewType).create(parent);
 	}
 
 	@Override
@@ -230,7 +249,7 @@ public abstract class GraywaterAdapter<
 	public void onBindViewHolder(final VH holder, final int viewHolderPosition) {
 
 		final BinderResult result = computeItemAndBinderIndex(viewHolderPosition);
-		final Binder binder = result.getBinder();
+		final Binder binder = result.getBinder().get();
 
 		if (binder != null && result.item != null) {
 
@@ -238,9 +257,7 @@ public abstract class GraywaterAdapter<
 				prepare(viewHolderPosition, binder, result.item, result.binderList, result.binderIndex);
 			}
 
-			final ActionListener actionListener = mActionListenerMap.get(getModelType(result.item));
-
-			binder.bind(result.item, holder, result.binderList, result.binderIndex, actionListener);
+			binder.bind(result.item, holder, result.binderList, result.binderIndex, getActionListener(result.item));
 
 			prepareInternal(viewHolderPosition);
 			mPreviousBoundViewHolderPosition = viewHolderPosition;
@@ -264,7 +281,7 @@ public abstract class GraywaterAdapter<
 			final int viewHolderPosition = lastBoundViewHolderPosition + direction * i;
 			if (isViewHolderPositionWithinBounds(viewHolderPosition)) {
 				final BinderResult result = computeItemAndBinderIndex(viewHolderPosition);
-				final Binder binder = result.getBinder();
+				final Binder binder = result.getBinder().get();
 
 				if (binder != null && result.item != null) {
 					prepare(viewHolderPosition, binder, result.item, result.binderList, result.binderIndex);
@@ -275,13 +292,13 @@ public abstract class GraywaterAdapter<
 
 	/**
 	 * Calls {@link Binder#prepare(Object, List, int)}.
-
+	 *
 	 * @param viewHolderPosition
-	 *      the position of the viewholder.
+	 * 		the position of the viewholder.
 	 * @param binder
-	 *      the binder to call.
+	 * 		the binder to call.
 	 * @param model
-	 *      the model being prepared.
+	 * 		the model being prepared.
 	 * @param binderList
 	 * 		the list of binders
 	 * @param binderIndex
@@ -290,10 +307,10 @@ public abstract class GraywaterAdapter<
 	protected void prepare(final int viewHolderPosition,
 	                       final Binder<T, VH, ? extends VH> binder,
 	                       final T model,
-	                       final List<Binder<? super T, VH, ? extends VH>> binderList,
+	                       final List<Provider<Binder<? super T, VH, ? extends VH>>> binderList,
 	                       final int binderIndex) {
 		if (!mViewHolderPreparedCache.contains(viewHolderPosition)) {
-			binder.prepare(model, binderList, binderIndex);
+			binder.prepare(model, (List) binderList, binderIndex);
 			mViewHolderPreparedCache.add(viewHolderPosition);
 		}
 	}
@@ -307,10 +324,10 @@ public abstract class GraywaterAdapter<
 	}
 
 	/**
-	 *  Checks if the timeline position is within the bounds of the underlying List
+	 * Checks if the timeline position is within the bounds of the underlying List
 	 *
 	 * @param itemPosition
-	 *      timeline item position.
+	 * 		timeline item position.
 	 * @return true if within list bounds. False otherwise.
 	 */
 	protected boolean isItemPositionWithinBounds(final int itemPosition) {
@@ -321,7 +338,7 @@ public abstract class GraywaterAdapter<
 	 * Checks if the viewholder is within the bounds of underlying list.
 	 *
 	 * @param viewHolderPosition
-	 *      viewholder position
+	 * 		viewholder position
 	 * @return true of within list bound. False otherwise.
 	 */
 	protected boolean isViewHolderPositionWithinBounds(final int viewHolderPosition) {
@@ -354,7 +371,7 @@ public abstract class GraywaterAdapter<
 	}
 
 	/**
-	 * Adds the given item to the adapter and notifies the adapter.
+	 * Note that this does not notify.
 	 *
 	 * @param item
 	 * 		the item to add to the adapter.
@@ -389,11 +406,10 @@ public abstract class GraywaterAdapter<
 	}
 
 	/**
-	 *
 	 * @param itemIndex
-	 *      the current view holders binder position.
+	 * 		the current view holders binder position.
 	 * @param viewHolderPosition
-	 *      the view holder position.
+	 * 		the view holder position.
 	 * @return the binder index associated with view holder.
 	 */
 	public int getBinderPosition(final int itemIndex, final int viewHolderPosition) {
@@ -413,7 +429,7 @@ public abstract class GraywaterAdapter<
 	public void add(final int position, @NonNull final T item, final boolean notify) {
 		final int numViewHolders = getViewHolderCount(position);
 
-		final List<Binder<? super T, VH, ? extends VH>> binders = getParts(item, position);
+		final List<Provider<Binder<? super T, VH, ? extends VH>>> binders = getParts(item, position);
 
 		mItems.add(position, item);
 		mBinderListCache.add(position, binders);
@@ -474,11 +490,11 @@ public abstract class GraywaterAdapter<
 
 			item = mItems.get(itemPosition);
 
-			final List<? extends Binder<? super T, VH, ? extends VH>> binders = mBinderListCache.get(itemPosition);
+			final List<Provider<Binder<? super T, VH, ? extends VH>>> binders = mBinderListCache.get(itemPosition);
 
 			mItems.remove(itemPosition);
 
-			for (final ListIterator<Integer> iter = mViewHolderToItemPositionCache.listIterator(); iter.hasNext();) {
+			for (final ListIterator<Integer> iter = mViewHolderToItemPositionCache.listIterator(); iter.hasNext(); ) {
 				if (iter.next() == itemPosition) {
 					iter.remove();
 				}
@@ -517,18 +533,18 @@ public abstract class GraywaterAdapter<
 	 * @param itemPosition
 	 * 		the position for the item that uses the view holder.
 	 * @param viewHolderClass
-	 *      the view holder type to look for.
+	 * 		the view holder type to look for.
 	 * @return the adapter data position for the view holder, or -1 if not found.
 	 */
 	public int getFirstViewHolderPosition(final int itemPosition, @NonNull final Class<? extends VH> viewHolderClass) {
 		if (isItemPositionWithinBounds(itemPosition) && mViewHolderClassToViewTypeMap.containsKey(viewHolderClass)) {
 			final int itemStartPos = getViewHolderCount(itemPosition);
 			int viewHolderIndex = 0;
-			final List<Binder<? super T, VH, ? extends VH>> binders = mBinderListCache.get(itemPosition);
+			final List<Provider<Binder<? super T, VH, ? extends VH>>> binders = mBinderListCache.get(itemPosition);
 			final int viewType = mViewHolderClassToViewTypeMap.get(viewHolderClass);
 			final T item = mItems.get(itemPosition);
-			for (Binder<? super T, VH, ? extends VH> binder : binders) {
-				if (binder.getViewType(item) == viewType) {
+			for (Provider<Binder<? super T, VH, ? extends VH>> binder : binders) {
+				if (binder.get().getViewType(item) == viewType) {
 					return itemStartPos + viewHolderIndex;
 				}
 				viewHolderIndex++;
@@ -579,7 +595,7 @@ public abstract class GraywaterAdapter<
 	protected void onViewRecycled(final VH holder, final int viewHolderPosition) {
 		if (isViewHolderPositionWithinBounds(viewHolderPosition)) {
 			final BinderResult result = computeItemAndBinderIndex(viewHolderPosition);
-			final Binder binder = result.getBinder();
+			final Binder binder = result.getBinder().get();
 
 			if (binder != null) {
 				mViewHolderPreparedCache.remove(viewHolderPosition);
@@ -588,7 +604,6 @@ public abstract class GraywaterAdapter<
 					binder.unbind(holder);
 				}
 			}
-			// N.B. this fails when remove() is called (note that the item is gone)
 		}
 	}
 
@@ -603,8 +618,8 @@ public abstract class GraywaterAdapter<
 	 * @return the binders that belong to the item at the given position.
 	 */
 	@Nullable
-	public List<Binder<? super T, VH, ? extends VH>> getBindersForPosition(final int itemPosition) {
-		final List<Binder<? super T, VH, ? extends VH>> binders;
+	public List<Provider<Binder<? super T, VH, ? extends VH>>> getBindersForPosition(final int itemPosition) {
+		final List<Provider<Binder<? super T, VH, ? extends VH>>> binders;
 
 		if (isItemPositionWithinBounds(itemPosition)) {
 			binders = mBinderListCache.get(itemPosition);
@@ -627,7 +642,7 @@ public abstract class GraywaterAdapter<
 		if (isItemPositionWithinBounds(itemPosition)) {
 			final int numViewHolders = getViewHolderCount(itemPosition);
 
-			final List<Binder<? super T, VH, ? extends VH>> binders = mBinderListCache.get(itemPosition);
+			final List<Provider<Binder<? super T, VH, ? extends VH>>> binders = mBinderListCache.get(itemPosition);
 
 			range = new Pair<>(numViewHolders, binders.size());
 		} else {
@@ -668,7 +683,7 @@ public abstract class GraywaterAdapter<
 		 * @param binderIndex
 		 * 		the index of the binder in the list of binders.
 		 */
-		void prepare(@NonNull U model, @NonNull List<Binder<? super U, V, ? extends V>> binderList, int binderIndex);
+		void prepare(@NonNull U model, List<Provider<Binder<? super U, V, ? extends V>>> binderList, int binderIndex);
 
 		/**
 		 * Called when {@link android.support.v7.widget.RecyclerView.Adapter#onBindViewHolder(RecyclerView.ViewHolder,
@@ -686,7 +701,7 @@ public abstract class GraywaterAdapter<
 		 * @param actionListener
 		 * 		the action listener to use
 		 */
-		void bind(@NonNull U model, @NonNull W holder, @NonNull List<Binder<? super U, V, ? extends V>> binderList,
+		void bind(@NonNull U model, @NonNull W holder, @NonNull List<Provider<Binder<? super U, V, ? extends V>>> binderList,
 		          int binderIndex, @NonNull ActionListener<U, V, W> actionListener);
 
 		/**
@@ -729,7 +744,7 @@ public abstract class GraywaterAdapter<
 	 * @param <V>
 	 * 		the viewholder type.
 	 * @param <B>
-	 *      the binder type.
+	 * 		the binder type.
 	 */
 	public interface ItemBinder<U, V extends RecyclerView.ViewHolder, B extends GraywaterAdapter.Binder<U, V, ? extends V>> {
 		/**
@@ -740,7 +755,7 @@ public abstract class GraywaterAdapter<
 		 * @return the list of binders to use.
 		 */
 		@NonNull
-		List<B> getBinderList(@NonNull U model, int position);
+		List<Provider<? extends B>> getBinderList(@NonNull U model, int position);
 	}
 
 	/**
@@ -767,7 +782,7 @@ public abstract class GraywaterAdapter<
 		 * 		an extra object for message passing.
 		 */
 		void act(@NonNull U model, @NonNull W holder, @NonNull View v,
-		         @NonNull List<Binder<? super U, V, ? extends V>> binderList,
+		         @NonNull List<Provider<Binder<? super U, V, ? extends V>>> binderList,
 		         int binderIndex, @Nullable Object obj);
 	}
 
@@ -797,7 +812,7 @@ public abstract class GraywaterAdapter<
 		/**
 		 * The list of binders.
 		 */
-		public List<Binder<? super U, V, ? extends V>> binders;
+		public List<Provider<Binder<? super U, V, ? extends V>>> binders;
 		/**
 		 * The index into the list of binders.
 		 */
@@ -828,7 +843,7 @@ public abstract class GraywaterAdapter<
 		 */
 		public void update(final ActionListener<U, V, W> actionListener,
 		                   @NonNull final U model, @NonNull final W holder,
-		                   @NonNull final List<Binder<? super U, V, ? extends V>> binders, final int binderIndex,
+		                   @NonNull final List<Provider<Binder<? super U, V, ? extends V>>> binders, final int binderIndex,
 		                   @Nullable final Object obj) {
 			this.model = model;
 			this.holder = holder;
@@ -863,7 +878,7 @@ public abstract class GraywaterAdapter<
 		 * The list of binders associated with the item.
 		 */
 		@Nullable
-		public final List<Binder<? super T, VH, ? extends VH>> binderList;
+		public final List<Provider<Binder<? super T, VH, ? extends VH>>> binderList;
 		/**
 		 * The index of the binder to use in the list of binders.
 		 */
@@ -881,7 +896,7 @@ public abstract class GraywaterAdapter<
 		 */
 		BinderResult(@Nullable final T item,
 		             final int itemPosition,
-		             @Nullable final List<Binder<? super T, VH, ? extends VH>> binderList,
+		             @Nullable final List<Provider<Binder<? super T, VH, ? extends VH>>> binderList,
 		             final int binderIndex) {
 			this.item = item;
 			this.itemPosition = itemPosition;
@@ -893,7 +908,7 @@ public abstract class GraywaterAdapter<
 		 * @return the binder to use.
 		 */
 		@Nullable
-		public Binder<? super T, VH, ? extends VH> getBinder() {
+		public Provider<Binder<? super T, VH, ? extends VH>> getBinder() {
 			return binderList != null && binderIndex >= 0 && binderIndex < binderList.size()
 					? binderList.get(binderIndex) : null;
 		}

--- a/graywater/src/main/java/com/tumblr/graywater/GraywaterAdapter.java
+++ b/graywater/src/main/java/com/tumblr/graywater/GraywaterAdapter.java
@@ -34,7 +34,6 @@ import java.util.Set;
  * 		the binder type.
  * @param <MT>
  * 		the type of the model type ({@code Class<T>} for example)
- * @see <a href="https://github.tumblr.net/TumblrMobile/android2/blob/master/graywater/README.md">README</a>
  */
 public abstract class GraywaterAdapter<
 		T,
@@ -310,7 +309,7 @@ public abstract class GraywaterAdapter<
 	                       final List<Provider<Binder<? super T, VH, ? extends VH>>> binderList,
 	                       final int binderIndex) {
 		if (!mViewHolderPreparedCache.contains(viewHolderPosition)) {
-			binder.prepare(model, (List) binderList, binderIndex);
+			binder.prepare(model, binderList, binderIndex);
 			mViewHolderPreparedCache.add(viewHolderPosition);
 		}
 	}
@@ -702,7 +701,7 @@ public abstract class GraywaterAdapter<
 		 * 		the action listener to use
 		 */
 		void bind(@NonNull U model, @NonNull W holder, @NonNull List<Provider<Binder<? super U, V, ? extends V>>> binderList,
-		          int binderIndex, @NonNull ActionListener<U, V, W> actionListener);
+		          int binderIndex, @Nullable ActionListener<U, V, W> actionListener);
 
 		/**
 		 * Called when {@link android.support.v7.widget.RecyclerView.Adapter#onViewRecycled(RecyclerView.ViewHolder)}

--- a/graywater/src/test/java/com/tumblr/graywater/GraywaterAdapterTest.java
+++ b/graywater/src/test/java/com/tumblr/graywater/GraywaterAdapterTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -98,7 +99,8 @@ public class GraywaterAdapterTest {
 
 			@Override
 			public void prepare(@NonNull final String model,
-			                    @NonNull final List<Binder<? super String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>> binderList,
+			                    final List<Provider<Binder<
+					                    ? super String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>> binderList,
 			                    final int binderIndex) {
 
 			}
@@ -106,9 +108,10 @@ public class GraywaterAdapterTest {
 			@Override
 			public void bind(@NonNull final String model,
 			                 @NonNull final TextViewHolder holder,
-			                 @NonNull final List<
-					                 Binder<? super String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>> binders,
-			                 final int binderIndex, @NonNull final ActionListener<String, RecyclerView.ViewHolder, TextViewHolder> actionListener) {
+			                 @NonNull final List<Provider<Binder<
+					                 ? super String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>> binderList,
+			                 final int binderIndex,
+			                 @NonNull final ActionListener<String, RecyclerView.ViewHolder, TextViewHolder> actionListener) {
 				((TextView) holder.itemView).setText(model);
 			}
 
@@ -126,7 +129,8 @@ public class GraywaterAdapterTest {
 
 			@Override
 			public void prepare(@NonNull final Uri model,
-			                    @NonNull final List<Binder<? super Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>> binders,
+			                    final List<Provider<Binder<
+					                    ? super Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>> binderList,
 			                    final int binderIndex) {
 
 			}
@@ -134,7 +138,8 @@ public class GraywaterAdapterTest {
 			@Override
 			public void bind(@NonNull final Uri model,
 			                 @NonNull final ImageViewHolder holder,
-			                 @NonNull final List<Binder<? super Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>> binders,
+			                 @NonNull final List<Provider<Binder<
+					                 ? super Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>> binderList,
 			                 final int binderIndex,
 			                 @NonNull final ActionListener<Uri, RecyclerView.ViewHolder, ImageViewHolder> actionListener) {
 				((ImageView) holder.itemView).setImageURI(model); // not a good idea in production ;)
@@ -152,8 +157,18 @@ public class GraywaterAdapterTest {
 			register(new TextViewHolderCreator(), TextViewHolder.class);
 			register(new ImageViewHolderCreator(), ImageViewHolder.class);
 
-			final TextBinder textBinder = new TextBinder();
-			final ImageBinder imageBinder = new ImageBinder();
+			final Provider<TextBinder> textBinder = new Provider<TextBinder>() {
+				@Override
+				public TextBinder get() {
+					return new TextBinder();
+				}
+			};
+			final Provider<ImageBinder> imageBinder = new Provider<ImageBinder>() {
+				@Override
+				public ImageBinder get() {
+					return new ImageBinder();
+				}
+			};
 
 			register(
 					String.class,
@@ -161,10 +176,10 @@ public class GraywaterAdapterTest {
 							TestBinder<String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>() {
 						@NonNull
 						@Override
-						public List<TestBinder<String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>> getBinderList(
-								@NonNull final String model,
-								final int position) {
-							return new ArrayList<TestBinder<String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>() {{
+						public List<Provider<? extends TestBinder<String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>>
+						getBinderList(@NonNull final String model, final int position) {
+							return new ArrayList<Provider<
+									? extends TestBinder<String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>>() {{
 								add(textBinder);
 								add(textBinder);
 							}};
@@ -177,10 +192,10 @@ public class GraywaterAdapterTest {
 							TestBinder<Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>() {
 						@NonNull
 						@Override
-						public List<TestBinder<Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>> getBinderList(
-								@NonNull final Uri model,
-								final int position) {
-							return new ArrayList<TestBinder<Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>() {{
+						public List<Provider<? extends TestBinder<Uri, RecyclerView.ViewHolder,
+								? extends RecyclerView.ViewHolder>>> getBinderList(@NonNull final Uri model, final int position) {
+							return new ArrayList<
+									Provider<? extends TestBinder<Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>>() {{
 								add(imageBinder);
 								add(imageBinder);
 								add(imageBinder);

--- a/graywater/src/test/java/com/tumblr/graywater/GraywaterAdapterTest.java
+++ b/graywater/src/test/java/com/tumblr/graywater/GraywaterAdapterTest.java
@@ -2,6 +2,7 @@ package com.tumblr.graywater;
 
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
@@ -111,7 +112,7 @@ public class GraywaterAdapterTest {
 			                 @NonNull final List<Provider<Binder<
 					                 ? super String, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>> binderList,
 			                 final int binderIndex,
-			                 @NonNull final ActionListener<String, RecyclerView.ViewHolder, TextViewHolder> actionListener) {
+			                 @Nullable final ActionListener<String, RecyclerView.ViewHolder, TextViewHolder> actionListener) {
 				((TextView) holder.itemView).setText(model);
 			}
 
@@ -141,7 +142,7 @@ public class GraywaterAdapterTest {
 			                 @NonNull final List<Provider<Binder<
 					                 ? super Uri, RecyclerView.ViewHolder, ? extends RecyclerView.ViewHolder>>> binderList,
 			                 final int binderIndex,
-			                 @NonNull final ActionListener<Uri, RecyclerView.ViewHolder, ImageViewHolder> actionListener) {
+			                 @Nullable final ActionListener<Uri, RecyclerView.ViewHolder, ImageViewHolder> actionListener) {
 				((ImageView) holder.itemView).setImageURI(model); // not a good idea in production ;)
 			}
 


### PR DESCRIPTION
For Graywater to display an item, it needs to know how to map an item to `ViewHolderCreators` (for inflating the view) and `Binders` (for binding the item to the view). In the middle are `ItemBinders`, which are simply lists of `Binders` that are needed for each item.

```
 Binders             ItemBinders                Items             Screen  
+--------+          +------------+          +-----------+       +--------+
| Photo  | -------- |            |       /- | TextPost  |       | Header |
+--------+    /---- | Photo Post | -\   /   +-----------+       +--------+
| Footer | --x /--- |            |   \----- | PhotoPost |       |        |
+--------+    x     +------------+    /     +-----------+       |        |
| Header | --x \--- |            | --/   /- | TextPost  |       | Text   |
+--------+    \---- | Text Post  |      /   +-----------+       |        |
| Text   | -------- |            | ----/                        |        |
+--------+          +------------+                              +--------+
```

Constructing the relationship between `ItemBinders` and `Binders` is necessary during initialization, because the complement of supported `ItemBinders` must be registered before items are added to the adapter. This can incur a large overhead if there are many types involved.

This pull request specifies the dependencies using Dagger 2 modules and leaves it up to Dagger to resolve the dependency graph using [multibindings](https://google.github.io/dagger/multibindings).

There are 3 multibinding maps:

* `Map<Class<?>, ItemBinder>`
* `Map<CreatorKey, ViewHolderCreator>`
* `Map<Class<?>, ActionListener>`

One may wonder why `Map<Class<?>, Binder>` is missing. It is unnecessary because the dependencies of every `ItemBinder` is known at compile time, but it is unknown which ItemBinders will be used in a list, since the list is not built until runtime. More importantly, it is easier to inject a `Map` than to inject each individual binder into the adapter.

To further improve initialization performance, we only construct the binders that are visible on screen.

```
 Binders             ItemBinders                Items             Screen  
+--------+          +------------+          +-----------+       +--------+
| Photo  |          |            |      /-- | TextPost  | -x--- | Header |
+--------+          | Photo Post |     /    +-----------+   \   +--------+
| Footer |          |            |    /     | PhotoPost |    \- |        |
+--------+          +------------+   /      +-----------+       |        |
| Header | ---\     |            | -/       | TextPost  |       | Text   |
+--------+     \--- | Text Post  |          +-----------+       |        |
| Text   | -------- |            |                              |        |
+--------+          +------------+                              +--------+
```

This works by changing `List<Binder>` to return `List<Provider<Binder>>`. Dagger 2 automatically supports `Provider<Binder>`, which allows us to defer the cost of binder initialization until the user scrolls. With the proper usage of scopes, extra initializations can be avoided.